### PR TITLE
Fix event in module uninstallation

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,7 @@
 HEAD
+	+ foreignModelInstance returns undef if foreignModel is
+	  undef. This happens when a module has been uninstalled and it is
+	  referenced in other installed module (events)
 	+ loggerd shows loaded LogHelpers when in debug mode
 	+ Added additional info to events from RAID watcher
 	+ Use sudo to remove temporal files/diectories in backup, avoiding

--- a/main/core/src/EBox/Events/Model/ConfigureDispatchers.pm
+++ b/main/core/src/EBox/Events/Model/ConfigureDispatchers.pm
@@ -63,12 +63,10 @@ sub headTitle
 #      This method is overridden since the showed data is managed
 #      differently.
 #
-#      - The data is already available from the eBox installation
+#      - The data is already available from the Zentyal installation
 #
 #      - The adding/removal of event dispatchers is done dynamically
-#      reading the directories where the event dispatcher are. The
-#      adding/removal is done installing or deinstalling ebox modules
-#      with dispatchers.
+#        by fetching them from the DispatcherProvider modules
 #
 #
 # Overrides:

--- a/main/core/src/EBox/Events/Model/ConfigureWatchers.pm
+++ b/main/core/src/EBox/Events/Model/ConfigureWatchers.pm
@@ -55,7 +55,7 @@ use constant ENT_URL => 'https://store.zentyal.com/enterprise-edition.html/?utm_
 #      - The data is already available from the Zentyal installation
 #
 #      - The adding/removal of event watchers is done dynamically
-#      reading the directories where the event watchers are placed
+#        by fetching them from the WatcherProvider modules
 #
 #
 # Overrides:

--- a/main/core/src/EBox/Types/HasMany.pm
+++ b/main/core/src/EBox/Types/HasMany.pm
@@ -134,8 +134,8 @@ sub foreignModelInstance
     my $directory = $value->{directory};
 
     # directory maybe undef if the HasMany is not yet created
-    $directory or
-        return undef;
+    # Some foreignModelAcquirers may return undef for a model
+    return undef unless ($directory and $modelName);
 
     my $model;
     my $manager = EBox::Model::Manager->instance();


### PR DESCRIPTION
- foreignModelInstance returns undef if foreignModel is
  undef. This happens when a module has been uninstalled and it is
  referenced in other installed module (events)
