### PR TITLE
Fix enable quotas without reboot

### DIFF
--- a/main/users/ChangeLog
+++ b/main/users/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fix enable quotas without rebooting when module is enabled.
 	+ Delete syncjournal files when slave is removed
 3.0.5
 	+ Fixed reinstall script to stop samba module, otherwise new slapd

--- a/main/users/debian/precise/control
+++ b/main/users/debian/precise/control
@@ -12,7 +12,7 @@ Vcs-Git: git://git.zentyal.org/zentyal.git
 Package: zentyal-users
 Architecture: all
 Replaces: ebox-usersandgroups (<< 2.0.100)
-Depends: zentyal-core (>= 3.0), zentyal-core (<< 3.0.100), zentyal-firewall, zentyal-dns, zentyal-ntp, slapd (>= 2.4.15), ldap-utils (>= 2.4.15), ldap-auth-config, slapd-smbk5pwd, libnet-ldap-perl, adduser, quota, libquota-perl, liburi-encode-perl, heimdal-kdc, libpam-heimdal, auth-client-config, ${misc:Depends}
+Depends: zentyal-core (>= 3.0), zentyal-core (<< 3.0.100), zentyal-firewall, zentyal-dns, zentyal-ntp, slapd (>= 2.4.15), ldap-utils (>= 2.4.15), ldap-auth-config, slapd-smbk5pwd, libnet-ldap-perl, adduser, quota, libquota-perl, liburi-encode-perl, heimdal-kdc, libpam-heimdal, auth-client-config, libsys-filesystem-perl, ${misc:Depends}
 Breaks: ebox-usersandgroups (<< 2.0.100)
 Description: Zentyal - Users and Groups
  Zentyal is a Linux small business server that can act as

--- a/main/users/src/EBox/UsersAndGroups/User.pm
+++ b/main/users/src/EBox/UsersAndGroups/User.pm
@@ -400,7 +400,7 @@ sub _setFilesystemQuota
     EBox::Sudo::root(QUOTA_PROGRAM . " -s $uid $quota");
 
     # check if quota has been really set
-    my $output =   EBox::Sudo::root(QUOTA_PROGRAM . " -q $uid");
+    my $output = EBox::Sudo::root(QUOTA_PROGRAM . " -q $uid");
     my ($afterQuota) = $output->[0] =~ m/(\d+)/;
     if ((not defined $afterQuota) or ($quota != $afterQuota)) {
         EBox::error(

--- a/main/users/src/scripts/enable-quotas
+++ b/main/users/src/scripts/enable-quotas
@@ -1,16 +1,33 @@
 #!/usr/bin/perl
 
+use strict;
+use warnings;
+
+use Sys::Filesystem;
+
+# Umount fuse filesystems to enable quota
+my $fs = Sys::Filesystem->new();
+my @filesystems = $fs->filesystems();
+foreach my $f (@filesystems) {
+    my $mountPoint = $fs->mount_point($f);
+    my $format = $fs->format($f);
+    if ($format =~ m/fuse\.gvfs-fuse-daemon/) {
+        system ("fusermount -u $mountPoint");
+    }
+}
+
+
 # Add quota support to fstab. It's set up for "/home" if exists,
 # otherwise we fall back to "/". Remount partition and turn quotas on
 
-open(FD, "/etc/fstab") or die "Could not open /etc/fstab";
+open (FD, "/etc/fstab") or die "Could not open /etc/fstab";
 my @fstab = <FD>;
-close(FD);
+close (FD);
 
 my $home = undef;
 my $root = undef;
 my $num = -1;
-for $line (@fstab) {
+for my $line (@fstab) {
     $num++;
     my @fields = split(/[\t\s]+/, $line);
     next if ($fields[0] =~ /^#.*/);
@@ -43,8 +60,13 @@ if ($line) {
     exit 1;
 }
 
-open(FD, ">/etc/fstab") or die "Could not write on /etc/fstab";
+open (FD, ">/etc/fstab") or die "Could not write on /etc/fstab";
 print FD @fstab;
-close(FD);
-system("/bin/mount -o remount $mount");
+close (FD);
+
+system ("/bin/mount -o remount $mount");
+
+# Enable quota
+system ("/etc/init.d/quota restart");
+
 exit 0;

--- a/main/users/src/scripts/user-quota
+++ b/main/users/src/scripts/user-quota
@@ -23,19 +23,19 @@
 #
 # Parameters are:
 #
-# -q uid  | -s uid quota
+# -q uidNumber  | -s uidNumber quota
 #
 # -q: query
 # -s: set
-# uid: user uid
+# uidNumber: user uidNumber
 # quota: quota size in KB
 use Quota;
 
 sub currentQuota
 {
-    my ($uid) = @_;
+    my ($uidNumber) = @_;
 
-    my @quotaValues = Quota::query( Quota::getqcarg('/home'), $uid);
+    my @quotaValues = Quota::query(Quota::getqcarg('/home'), $uidNumber);
     if (@quotaValues) {
         return $quotaValues[1];
     } else {
@@ -45,20 +45,31 @@ sub currentQuota
 
 sub setCurrentQuota
 {
-    my ($uid, $quota) = @_;
+    my ($uidNumber, $quota) = @_;
 
     my $ok = Quota::setqlim(Quota::getqcarg('/home'),
-                   $uid, $quota, $quota, 0, 0);
+                   $uidNumber, $quota, $quota, 0, 0);
     if (not defined $ok) {
         my $err = Quota::strerr();
         die $err;
     }
 }
 
+sub usage
+{
+    print "Usage: user-quota [options]\n";
+    print "  Options:\n";
+    print "     -q uidNumber            Print current quota\n";
+    print "     -s uidNumber quota      Sets quota for user\n";
+}
+
 if ($ARGV[0] eq '-s') {
     setCurrentQuota($ARGV[1], $ARGV[2]);
-} else {
+} elsif ($ARGV[0] eq '-q') {
     print currentQuota($ARGV[1]);
+} else {
+    usage();
+    exit 1;
 }
 
 exit 0;


### PR DESCRIPTION
The fuse filesystems need to be umounted before enabling quota.
See bug https://bugs.launchpad.net/ubuntu/+source/gvfs/+bug/225361
