### PR TITLE
Two fixes related to user sync between samba and zentyal

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Set kerberos keys when importing users from samba to zentyal
 	+ Fix ACLs for system type shares
 3.0.8
 	+ Depend on Samba4 RC5

--- a/main/users/ChangeLog
+++ b/main/users/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Set userPassword attribute when setting kerberos keys for user
 	+ Fixed delGroup operation on cloud slave
 	+ Include exception message when there is an error notifying a slave
 	+ Fix enable quotas without rebooting when module is enabled

--- a/main/users/src/EBox/UsersAndGroups/User.pm
+++ b/main/users/src/EBox/UsersAndGroups/User.pm
@@ -951,7 +951,8 @@ sub setKerberosKeys
         throw EBox::Exceptions::Internal($asn_key->error());
         push (@{$blobs}, $blob);
     }
-        $self->set('krb5Key', $blobs);
+    $self->set('krb5Key', $blobs);
+    $self->set('userPassword', '{K5KEY}');
 }
 
 1;


### PR DESCRIPTION
- Set the kerberos keys when importing user from samba
- Write the userPassword attribute when setting the kerberos keys
  on zentyal LDAP
