### PR TITLE
Fixed bug that made that the lock was shared between owners

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fixed bug that made that the lock was shared between owners
 	+ Some fixes in the function to add the rule for desktops services
 	  to the firewall
 3.0.7


### PR DESCRIPTION
Very important. Make that backups process could overlap and I am sure that most of errors of 'could not lock foo' has its origin there.
