### PR TITLE
Two fixes in unregistering monitor restart

### DIFF
--- a/main/common/src/EBox/Sudo.pm
+++ b/main/common/src/EBox/Sudo.pm
@@ -49,10 +49,10 @@ BEGIN {
 
 use Readonly;
 Readonly::Scalar our $SUDO_PATH   => '/usr/bin/sudo -p sudo:'; # our declaration eases testing
-Readonly::Scalar our  $STDERR_FILE =>  EBox::Config::tmp() . 'stderr';
+Readonly::Scalar our $STDERR_FILE =>  EBox::Config::tmp() . 'stderr';
 
 Readonly::Scalar my $STAT_CMD => '/usr/bin/stat -c%dI%iI%fI%hI%uI%gIhI%sI%XI%YI%ZI%oI%bI%tI%T';
-Readonly::Scalar my  $TEST_PATH   => '/usr/bin/test';
+Readonly::Scalar my $TEST_PATH   => '/usr/bin/test';
 
 # Procedure: system
 #

--- a/main/monitor/ChangeLog
+++ b/main/monitor/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Remove bad links as well while unregistering
+	+ Fix keep of monitor history after unregistering
 3.0.2
 	+ Avoided infinite recursion incidents when instantiating new
 	  measure objects

--- a/main/monitor/src/EBox/Monitor.pm
+++ b/main/monitor/src/EBox/Monitor.pm
@@ -540,8 +540,8 @@ sub _setMainConf
         $self->_setOldHostname($hostname);
     } elsif ($oldFqdn ne $hostname) {
         $self->_changeRRDDirs($oldFqdn, $hostname);
-        $self->_removeSubscriptionLink(); # to assure we have al inkpointing to
-                                         # the good directory
+        $self->_removeSubscriptionLink(1); # to assure we have a link pointing to
+                                           # the good directory
         $self->_setOldHostname($hostname);
     }
 
@@ -554,7 +554,7 @@ sub _setMainConf
             @networkServers = @{$rs->monitorGathererIPAddresses()};
             $self->_makeSubscriptionLink($hostname);
         } else {
-            $self->_removeSubscriptionLink();
+            $self->_removeSubscriptionLink(1);
         }
     }
 
@@ -693,12 +693,13 @@ sub _removeSubscriptionLink
     my $parentPath = EBox::Monitor::Configuration::RRD_BASE_DIR;
     opendir(my $dh, $parentPath);
     while ( defined(my $subdir = readdir($dh)) ) {
-        if ($subdir =~ m{^[0-9a-zA-Z-]+$}) {
+        if ($subdir =~ m{^[0-9a-zA-Z-]+$} and length($subdir) == 36) {
             # Stop the service before removing to avoid race conditions
             $self->_stopService() if $stopService;
+            my $path = "$parentPath/$subdir";
             # seems a subscription directory link, check if is a symbolink link
-            if (EBox::Sudo::fileTest('-L', $subdir)) {
-                EBox::Sudo::root("rm $parentPath/$subdir");
+            if (EBox::Sudo::fileTest('-L', $path) or (not EBox::Sudo::fileTest('-e', $path)) ) {
+                EBox::Sudo::root("rm '$path'");
             } else {
                 # to avoid lose data we will move it to rrd path based in
                 # hostname (it overwrites rrd base path if exists but the
@@ -706,10 +707,9 @@ sub _removeSubscriptionLink
                 my $rrdBaseDirPath = $self->rrdBaseDirPath();
                 EBox::Sudo::root(
                                   "rm -rf '$rrdBaseDirPath'",
-                                  "mv -f  '$parentPath/$subdir' '$rrdBaseDirPath'"
+                                  "mv -f  '$path' '$rrdBaseDirPath'"
                                  );
             }
-
             last;
         }
     }


### PR DESCRIPTION
This avoids 100% CPU in some cases
- Remove bad links as well while unregistering
- Fix keep of monitor history after unregistering

This should do well :)
