### PR TITLE
Fixed sendInPlaceBooleanValue method from table-helper.js; it  aborted b...

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Fixed sendInPlaceBooleanValue method from table-helper.js; it
+	  aborted because bad parameters of Ajax.Updater
 	+ Fixed bug that made that the lock was shared between owners
 	+ Some fixes in the function to add the rule for desktops services
 	  to the firewall

--- a/main/core/www/js/table-helper.js
+++ b/main/core/www/js/table-helper.js
@@ -1046,15 +1046,13 @@ function sendInPlaceBooleanValue(controller, model, id, dir, field, element)
     hide(element.id);
     setLoading(element.id + '_loading');
 
-    var MyAjax = new Ajax.Updater(
-                {
-                        failure: 'error_' + model
-                },
+    var MyAjax = new Ajax.Request(
         controller,
         {
             method: 'post',
             parameters: parameters,
             onFailure: function(t) {
+              $('error_' + model).innerHTML = t.responseText;
               completedAjaxRequest();
               show(element.id);
               $(element.id + '_loading').innerHTML = '';
@@ -1068,7 +1066,6 @@ function sendInPlaceBooleanValue(controller, model, id, dir, field, element)
 
             }
         });
-
 
 }
 /*


### PR DESCRIPTION
...ecause bad parameters of Ajax.Updater. We were lucky because the abort was after the expected actions so it seems that it worked by chance.
