### PR TITLE
Fixed bug which used all addresses available in a interface to  generate...

### DIFF
--- a/main/dhcp/ChangeLog
+++ b/main/dhcp/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Fixed bug which used all addresses available in a interface to
+	  generate DNS reverse zone instead of the configured ranges
 3.0.2
 	+ Always write ddns keys file when saving changes
 	+ Do not append trailing dot to key names

--- a/main/dhcp/src/EBox/DHCP.pm
+++ b/main/dhcp/src/EBox/DHCP.pm
@@ -1410,22 +1410,23 @@ sub _reverseZones
 {
     my ($self, $iface) = @_;
 
-    my $initRange = $self->initRange($iface);
-    $initRange =~ s/1$/0/; # To make a network interface
-    my $endRange  = $self->endRange($iface);
+    my @ranges = @{ $self->ranges($iface) };
 
     my @revZones;
-    my $ip = new Net::IP("$initRange - $endRange");
-    do {
-        my $rev = Net::IP->new($ip->ip())->reverse_ip();
-        if ( defined($rev) ) {
-            # It returns 0.netaddr.in-addr.arpa so we need to remove it
-            # to make it compilant with bind zone definition
-            $rev =~ s/^0\.//;
-            push(@revZones, $rev);
-        }
-    } while ( $ip += 256 );
-
+    foreach my $range (@ranges) {
+        my $initRange = $range->{from};
+        my $endRange  = $range->{to};
+        my $ip = new Net::IP("$initRange - $endRange");
+        do {
+            my $rev = Net::IP->new($ip->ip())->reverse_ip();
+            if ( defined($rev) ) {
+                # It returns 0.netaddr.in-addr.arpa so we need to remove it
+                # to make it compilant with bind zone definition
+                $rev =~ s/^0\.//;
+                push(@revZones, $rev);
+            }
+        } while ( $ip += 256 );
+    }
     return \@revZones;
 }
 


### PR DESCRIPTION
... DNS reverse zone instead of the configured ranges.

However it takes the reverse zones in blocks of 255 addresses,I don't fix this now because it could not be compatible with DNS module's reverse zones. It would require more tinkering
