### PR TITLE
duplicity-wrapper uses C locale to avoid locale problems

### DIFF
--- a/main/ebackup/ChangeLog
+++ b/main/ebackup/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ duplicity-wrapper uses C locale to avoid locale problems
 	+ Removed superfluous module lock in backup-tool
 	+ Removed independent implementation of lock and unlock methods
 	+ Fix small syntax error

--- a/main/ebackup/src/scripts/duplicity-wrapper
+++ b/main/ebackup/src/scripts/duplicity-wrapper
@@ -94,6 +94,6 @@ if ($debug) {
     system "echo $cmdMsg >> $cmdLogFile";
 }
 
-$ENV{LANG} ='en_US.UTF-8';
+EBox::setLocaleEnvironment('C.UTF-8');
 exec $duplicityCommand or
     exit 2;


### PR DESCRIPTION
This bug was flying under the radar because duplcity translation is not advanced in languages like spanish but german users reported the problem
