### PR TITLE
Dont' restrict characters in data table searchs

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Dont' restrict characters in data table searchs
 	+ Fixed refresh of the table and temporal control states
 	  in customActionClicked callback
 	+ Modified modalbox-zentyal.js to accept wideDialog parameter

--- a/main/core/src/EBox/CGI/Controller/DataTable.pm
+++ b/main/core/src/EBox/CGI/Controller/DataTable.pm
@@ -66,7 +66,7 @@ sub getParams
     }
 
     $params{'id'} = $self->unsafeParam('id');
-    $params{'filter'} = $self->param('filter');
+    $params{'filter'} = $self->unsafeParam('filter');
 
     my $cloneId = $self->unsafeParam('cloneId');
     if ($cloneId) {
@@ -334,7 +334,7 @@ sub refreshTable
     my $global = EBox::Global->getInstance();
 
     my $action =  $self->{'action'};
-    my $filter = $self->param('filter');
+    my $filter = $self->unsafeParam('filter');
     my $page = $self->param('page');
     my $pageSize = $self->param('pageSize');
     if ( defined ( $pageSize )) {


### PR DESCRIPTION
A generic method liek this should not have this limitation. Also the characters are used to be compared with the fields values, not used for generate commands, html or the like so no problem here.
