### PR TITLE
Change value of squid variable visible_hostname

### DIFF
--- a/main/squid/ChangeLog
+++ b/main/squid/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Set visible_hostname to host '(instance)FQDN'. The standard value
+	  'localhost' causes access denied under certain circumstances
 	+ Ignore access rules for empty objects
 	+ Ignore access rules for empty groups
 	+ Mark module as changed if addition/removal of users modify ACLs

--- a/main/squid/src/EBox/Squid.pm
+++ b/main/squid/src/EBox/Squid.pm
@@ -563,12 +563,11 @@ sub _writeSquidConf
     my $squidFilterProfiles = $accesRulesModel->squidFilterProfiles();
 
     my $generalSettings = $self->model('GeneralSettings');
-    my $kerberos     = $generalSettings->kerberosValue();
+    my $kerberos = $generalSettings->kerberosValue();
 
     my $global  = $self->global();
     my $network = $global->modInstance('network');
     my $sysinfo = $global->modInstance('sysinfo');
-
 
     my $users = $global->modInstance('users');
 
@@ -589,6 +588,7 @@ sub _writeSquidConf
     push @writeParam, ('rules' => $rules);
     push @writeParam, ('filterProfiles' => $squidFilterProfiles);
 
+    push @writeParam, ('hostfqdn' => $sysinfo->fqdn());
     push @writeParam, ('auth' => $self->authNeeded());
     push @writeParam, ('principal' => $krbPrincipal);
     push @writeParam, ('realm'     => $krbRealm);
@@ -609,12 +609,14 @@ sub _writeSquidExternalConf
     my $globalRO = EBox::Global->getInstance(1);
     my $global  = $self->global();
     my $network = $global->modInstance('network');
-    my $users = $global->modInstance('users');
+    my $users   = $global->modInstance('users');
+    my $sysinfo = $global->modInstance('sysinfo');
     my $generalSettings = $self->model('GeneralSettings');
 
     my $writeParam = [];
 
     push (@{$writeParam}, port => SQUID_EXTERNAL_PORT);
+    push (@{$writeParam}, hostfqdn => $sysinfo->fqdn());
 
     if ($generalSettings->kerberosValue()) {
         push (@{$writeParam}, realm => $users->kerberosRealm);

--- a/main/squid/stubs/squid-external.conf.mas
+++ b/main/squid/stubs/squid-external.conf.mas
@@ -9,6 +9,7 @@
     $port
     $transparent    => undef
 
+    $hostfqdn
     $realm => ''
 
     $memory
@@ -157,7 +158,7 @@ snmp_access deny all
 http_port localhost:<% $port %>
 
 
-visible_hostname localhost-external
+visible_hostname (external)<% $hostfqdn %>
 
 coredump_dir /var/spool/squid3
 cache_log /var/log/squid3/cache-external.log

--- a/main/squid/stubs/squid.conf.mas
+++ b/main/squid/stubs/squid.conf.mas
@@ -11,6 +11,7 @@
     $https       => undef
     $filter
 
+    $hostfqdn
     $auth
     $principal
     $realm
@@ -203,7 +204,7 @@ acl <% _aclName($timeHoursPrefix . $id) %> time <% $rule->{timeHours} %>
 http_port <% $port %> <% $transKey%> <% $sslBumpOptions %>
 # END_TAG #
 
-visible_hostname localhost
+visible_hostname (frontal)<% $hostfqdn %>
 coredump_dir /var/spool/squid3
 cache_effective_user proxy
 cache_effective_group proxy


### PR DESCRIPTION
The default value 'localhost' causes access denied under certain
circumstances
