### PR TITLE
Fixed bug which allowed bad long names for ACL for all object. Replace b...

### DIFF
--- a/main/squid/ChangeLog
+++ b/main/squid/ChangeLog
@@ -1,4 +1,7 @@
 HEAD
+	+ Replace blanks for categorized lists directories to workaround
+	  squid bug
+	+ Fixed bug which allowed bad long names for ACL for 'all' object
 	+ Ignore access rules for empty objects
 	+ Ignore access rules for empty groups
 	+ Mark module as changed if addition/removal of users modify ACLs

--- a/main/squid/src/EBox/Squid/Model/CategorizedLists.pm
+++ b/main/squid/src/EBox/Squid/Model/CategorizedLists.pm
@@ -55,7 +55,9 @@ sub _table
              allowDownload => 1,
              dynamicPath   => sub {
                                 my ($self) = @_;
-                                return LIST_FILE_DIR . '/' . $self->row()->valueByName('name');
+                                my $name = $self->row()->valueByName('name');
+                                $name =~ s/\s/_/g;
+                                return LIST_FILE_DIR . '/' .$name;
                               },
              user          => 'ebox',
              group         => 'ebox',

--- a/main/squid/stubs/squid.conf.mas
+++ b/main/squid/stubs/squid.conf.mas
@@ -138,7 +138,7 @@ sub _printSplitAcl
    if ($rule->{any}) {
        $objectAcl = 'all';
    } elsif ($object) {
-       $objectAcl = _aclName($objectPrefix . $object);
+       $objectAcl = $objectPrefix . $object;
    } else {
        $objectAcl = '';
    }
@@ -146,12 +146,13 @@ sub _printSplitAcl
    my $group = $rule->{'group'};
    my $groupAcl;
    if ($group) {
-      $groupAcl = _aclName($groupPrefix . $group);
+      $groupAcl = $groupPrefix . $group;
   } else {
       $groupAcl = '';
   }
 
    my $acl = $groupAcl ? $groupAcl : $objectAcl;
+   $acl = _aclName($acl);
    my $timeAcls = _timeAclsInPolicy($rule, $object, $group);
    my $policy = $rule->{'policy'};
    if ($policy eq 'profile') {


### PR DESCRIPTION
...lanks for categorized lists directories to workaround  squid bug

Unfortunately this is not backwards  compatible with already set categorized lists with spaces in its names
