### PR TITLE
Fix regression to register a server with comm add-on

### DIFF
--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fix regression to register a server with communication add-on
 	+ Fix restore/backup procedure for the module
 3.0.9
 	+ More resilient reporting operations to reporter errors

--- a/main/remoteservices/src/EBox/RemoteServices/Subscription.pm
+++ b/main/remoteservices/src/EBox/RemoteServices/Subscription.pm
@@ -201,7 +201,7 @@ sub subscribeServer
 
         my $checker = new EBox::RemoteServices::Subscription::Check();
         # Check the available editions are suitable for this server
-        my @availables = grep { $checker->check($_->{subscription}, $_->{comm_mail_add_on}) } @{$availables};
+        my @availables = grep { $checker->check($_->{subscription}, $_->{sb_comm_add_on}) } @{$availables};
 
         given ( scalar(@availables) ) {
             when (0) {


### PR DESCRIPTION
This is quite urgent since servers with comm add-on cannot register his server.

Wait for DR fix if you think it's worth.
