### PR TITLE
Generate kerberos AES 256 and AES 128 keys

### DIFF
--- a/main/users/ChangeLog
+++ b/main/users/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Generate kerberos AES keys to be compatible with active directory in
+	  W2k8 or higher functional levels
 	+ Fixed user quota edition in slave server
 	+ Update user password also in samba ldap when changed from user corner
 	+ Update 'cn' attribute in cloud-sync

--- a/main/users/stubs/krb5.conf.mas
+++ b/main/users/stubs/krb5.conf.mas
@@ -10,4 +10,4 @@
     preferred_enctypes   = arcfour-hmac-md5 des-cbc-md5 dec-cbc-crc
 
 [kadmin]
-    default_keys = des-cbc-crc:pw-salt des-cbc-md5:pw-salt arcfour-hmac-md5:pw-salt
+    default_keys = des-cbc-crc:pw-salt des-cbc-md5:pw-salt arcfour-hmac-md5:pw-salt aes256-cts-hmac-sha1-96:pw-salt aes128-cts-hmac-sha1-96:pw-salt


### PR DESCRIPTION
Necessary to be compatible with active directory working in W2k8
or higher functional levels
