### PR TITLE
Fix reload bundle checks with communication add-on

### DIFF
--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fix reload bundle checks with communication add-on
 	+ Restore process can skip backed up credentials when it is sure
 	  the current credentials are up to date for the same server
 	+ Fix regression to register a server with communication add-on

--- a/main/remoteservices/src/EBox/RemoteServices/Subscription/Check.pm
+++ b/main/remoteservices/src/EBox/RemoteServices/Subscription/Check.pm
@@ -155,7 +155,7 @@ sub checkFromCloud
     my $det = $capabilitiesGetter->subscriptionDetails();
 
     if ( $det->{codename} eq 'sb' ) {
-        $self->_performSBChecks();
+        $self->_performSBChecks($det->{sb_comm_add_on});
     }
     return 1;
 }


### PR DESCRIPTION
Reload bundle was not working for communication add-on servers
