### PR TITLE
Added workaround for launchpad bug 994509, which manifests  showing dupl...

### DIFF
--- a/main/software/ChangeLog
+++ b/main/software/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Added workaround for launchpad bug 994509, which manifests
+	  showing duplicate packages in the updates list
 	+ Hide enable automatic updates form when it cannot be used
 	+ Errors when getting packages dependencies are displayed, this
 	  fixes the empty dialog on error problem

--- a/main/software/src/EBox/Software.pm
+++ b/main/software/src/EBox/Software.pm
@@ -785,9 +785,17 @@ sub _getInfoEBoxPkgs
 
     my $cache = $self->_cache(1);
     my @list;
+
+    my %seen; # XXX workaround launchpad bug 994509
     for my $pack (keys %$cache) {
         if ($pack =~ /^zentyal-.*/) {
             next if $restricted{$pack};
+
+            if ($seen{$pack}) {
+                next;
+            } else {
+                $seen{$pack} = 1;
+            }
 
             my $pkgCache = $cache->packages()->lookup($pack) or next;
             my %data;
@@ -825,7 +833,14 @@ sub _getUpgradablePkgs
 
     my $cache = $self->_cache(1);
     my @list;
+    my %seen; # XXX workaround launchpad bug 994509
     for my $pack (keys %$cache) {
+        if ($seen{$pack}) {
+            next;
+        } else {
+            $seen{$pack} = 1;
+        }
+
         my $pkgCache = $cache->packages()->lookup($pack) or next;
 
         my $currentVerObj = $cache->{$pack}{CurrentVer};


### PR DESCRIPTION
...icate packages in the updates list

see https://bugs.launchpad.net/ubuntu/+source/libapt-pkg-perl/+bug/994509 for the bug work-arounded.

I dont know which triggers this bug. I have seen it reported 4-5  times. The last one in Mateo's system
