### PR TITLE
Dont stop openldap daemon when dumping database

### DIFF
--- a/main/users/ChangeLog
+++ b/main/users/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Dont stop openldap daemon when dumping database
 	+ Generate kerberos AES keys to be compatible with active directory in
 	  W2k8 or higher functional levels
 	+ Fixed user quota edition in slave server


### PR DESCRIPTION
This is to avoid service pauses when backing up
