### PR TITLE
In EBox::Samba::setupDNS create DNS configuration for local  domain if i...

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ In EBox::Samba::setupDNS create DNS configuration for local
+	  domain if it does not exists
 	+ Grant rx access on privileged ldap socket to allow user corner to
 	  update user passwords
 3.0.9

--- a/main/samba/src/EBox/Samba.pm
+++ b/main/samba/src/EBox/Samba.pm
@@ -1087,13 +1087,16 @@ sub setupDNS
 
     my $dnsModule = EBox::Global->modInstance('dns');
     my $sysinfo = EBox::Global->modInstance('sysinfo');
+    my $hostDomain = $sysinfo->hostDomain();
 
     # Ensure that the managed domain exists
     my $domainModel = $dnsModule->model('DomainTable');
-    my $domainRow = $domainModel->find(domain => $sysinfo->hostDomain());
+
+    my $domainRow = $domainModel->find(domain => $hostDomain);
     unless (defined $domainRow) {
-        throw EBox::Exceptions::Internal("Domain named '" . $sysinfo->hostDomain()
-            . "' not found");
+        EBox::info("Adding $hostDomain to DNS managed domains");
+        my $newId = $domainModel->addRow(domain => $hostDomain);
+        $domainModel = $domainModel->row($newId);
     }
 
     # Mark the domain as samba


### PR DESCRIPTION
...t does not exists

I have done this to simplify setup.

If you think it is too much automaticaly setup, then the itnernal exception must be replaced by a external one because this method could be called when setEnable(0) and i nthis case the exception could be somewhat cryptic
