### PR TITLE
Fixed LdapObject::get() for list context

### DIFF
--- a/main/users/ChangeLog
+++ b/main/users/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fixed LdapObject::get() for list context
 	+ Decode utf8 attributes from LDAP at LdapObject::get()
 	+ Removed unused method _utf8Attrs
 	+ Integration with Disaster Recovery service

--- a/main/users/src/EBox/UsersAndGroups/LdapObject.pm
+++ b/main/users/src/EBox/UsersAndGroups/LdapObject.pm
@@ -100,11 +100,18 @@ sub get
 {
     my ($self, $attr) = @_;
 
-    my $value = $self->_entry->get_value($attr);
-    utf8::decode($value);
-    return $value;
+    if (wantarray()) {
+        my @value = $self->_entry->get_value($attr);
+        foreach my $el (@value) {
+            utf8::decode($el);
+        }
+        return @value;
+    } else {
+        my $value = $self->_entry->get_value($attr);
+        utf8::decode($value);
+        return $value;
+    }
 }
-
 
 # Method: set
 #


### PR DESCRIPTION
Remember that LDAP::Entry for multi-value atributes must be called in list context and return a list, not a reference to a list. 

Anyway in case it returned a reference of a list, it would be wrong also because the call to utf8::decode on the reference
