### PR TITLE
added unmanaged_acls option

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ New advanced 'unmanaged_acls' option in /etc/zentyal/samba.conf to
+	  disable overwriting of ACLs when saving changes
 	+ shareByFilename method now also returns the path and type of the share
 	+ Fix shareByFilename method
 	+ Update Loghelper to the new log formats

--- a/main/samba/conf/samba.conf
+++ b/main/samba/conf/samba.conf
@@ -104,3 +104,7 @@ show_site_box = no
 # taking as samAccountName the mail account name. It is
 # usefull to import to Zentyal AD mail distribution groups
 treat_contacts_as_users = no
+
+# Uncomment this if you want to set ACLs manually and avoid
+# Zentyal to overwrite them
+#unmanaged_acls = yes

--- a/main/samba/src/EBox/Samba/Model/SambaShares.pm
+++ b/main/samba/src/EBox/Samba/Model/SambaShares.pm
@@ -295,6 +295,10 @@ sub createDirs
         }
         next unless defined $path;
 
+        # Don't do anything if the directory already exists and the option to manage ACLs
+        # only from Windows is set
+        next if (EBox::Config::boolean('unmanaged_acls') and EBox::Sudo::fileTest('-d', $path));
+
         my @cmds = ();
         push (@cmds, "mkdir -p '$path'");
         push (@cmds, "setfacl -b '$path'"); # Clear POSIX ACLs


### PR DESCRIPTION
This allows modification of ACLs from Windows, as Zentyal won't overwrite them if unmanaged_acls = yes is set

This is an option only for advanced users, as ACL changes on the Zentyal interface won't be applied as well if this option is set.
