### PR TITLE
Added read-only rootDn and password to LDAP settings screen

### DIFF
--- a/main/users/ChangeLog
+++ b/main/users/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Added read-only rootDn and password to LDAP settings screen
 	+ Don't allow empty first name in CGIs for user
 	  creation/modification. Otherwise you can get LDAP errors.
 	+ Operator typo fix in EBox::UsersAndGroup::User::_checkQuota

--- a/main/users/src/EBox/UsersAndGroups/Model/LdapInfo.pm
+++ b/main/users/src/EBox/UsersAndGroups/Model/LdapInfo.pm
@@ -50,6 +50,14 @@ sub _table
             printableName => __('Password'),
         ),
         new EBox::Types::Text (
+            fieldName => 'roRootDn',
+            printableName => __('Read-only root DN'),
+        ),
+        new EBox::Types::Text (
+            fieldName => 'roPassword',
+            printableName => __('Read-only password'),
+        ),
+        new EBox::Types::Text (
             fieldName => 'usersDn',
             printableName => __('Users DN'),
         ),
@@ -86,11 +94,15 @@ sub _content
     my ($self) = @_;
 
     my $users = $self->parentModule();
-
+    my $ldap = $users->ldap();
     return {
-        dn => $users->ldap()->dn(),
-        rootDn => $users->ldap()->rootDn(),
-        password => $users->ldap()->getPassword(),
+        dn => $ldap->dn(),
+        rootDn => $ldap->rootDn(),
+        password => $ldap->getPassword(),
+
+        roRootDn   => $ldap->roRootDn(),
+        roPassword => $ldap->getRoPassword(),
+
         usersDn => $users->usersDn(),
         groupsDn => $users->groupsDn(),
     }


### PR DESCRIPTION
As told in http://trac.zentyal.org/ticket/6012 :

Most (3rd party) services that would make use of the central ldap authentication do not require (and mostly should not) get write access to ldap. So for these services, the zentyalro user and password is much more important than the one shown that has full credentials. For many users, it is not even apparent that there is a Read-Only user available 

I agree with the above and the change is trivial so it is done in this branch
