### PR TITLE
Fix typo

### DIFF
--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Fix typo in execute bundle which avoids correct installation of
+	  cloud-prof when registration is done
 3.0.13
 	+ Notify cloud-prof when installed when changes happen in
 	  DisasterRecoveryDomains model

--- a/main/remoteservices/src/EBox/RemoteServices/Subscription.pm
+++ b/main/remoteservices/src/EBox/RemoteServices/Subscription.pm
@@ -770,7 +770,7 @@ sub _restartRS
     $fw->save();
     # Required to set the CA correctly
     my $apache = $global->modInstance('apache');
-    $apache-save();
+    $apache->save();
 }
 
 # Downgrade current subscription, if necessary


### PR DESCRIPTION
- Fix typo in execute bundle which avoids correct installation of
  cloud-prof when registration is done

Important
