### PR TITLE
Removed unnecesary and misleadin method new from EBox::ThirdParty::Apach...

### DIFF
--- a/main/captiveportal/ChangeLog
+++ b/main/captiveportal/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Removed unnecesary and misleading method 'new' from EBox::CaptivePortal::Auth package
 3.0.1
 	+ Adapted to the new utf8 fixes
 	+ Removed superfluos calls to utf8::decode

--- a/main/captiveportal/src/EBox/CaptivePortal/Auth.pm
+++ b/main/captiveportal/src/EBox/CaptivePortal/Auth.pm
@@ -41,14 +41,8 @@ use YAML::XS;
 # Session files dir, +rw for captiveportal & zentyal
 use constant UMASK => 0007; # (Bond, James Bond)
 
-sub new
-{
-    my $class = shift;
-    my $self = {};
-    bless($self, $class);
-    return $self;
-}
-
+# Method: _savesession
+#
 # Parameters:
 #
 #   - user name

--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Removed unnecesary and misleading method new from EBox::Auth package
 3.0.11
 	+ Avoid flickering loading pages when switching between menu entries
 	+ Incorrect regular expression in logs search page are correctly handled

--- a/main/core/src/EBox/Auth.pm
+++ b/main/core/src/EBox/Auth.pm
@@ -42,14 +42,8 @@ use constant MAX_SCRIPT_SESSION => 10; # In seconds
 # Remote access constants
 use constant CC_USER => '__remote_access__';
 
-sub new
-{
-    my $class = shift;
-    my $self = {};
-    bless($self, $class);
-    return $self;
-}
-
+# Method: _savesession
+#
 # Parameters:
 #
 #   - session id : if the id is undef, it truncates the session file

--- a/main/usercorner/ChangeLog
+++ b/main/usercorner/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Removed unnecesary and misleading method 'new' from EBox::UserCorner::Auth package
 3.0.3
 	+ Adapted to the new utf8 fixes
 	+ Removed suprefluos calls to utf8::decode

--- a/main/usercorner/src/EBox/UserCorner/Auth.pm
+++ b/main/usercorner/src/EBox/UserCorner/Auth.pm
@@ -44,14 +44,8 @@ use constant EXPIRE => 3600; #In seconds  1h
 # By now, the expiration time for a script session
 use constant MAX_SCRIPT_SESSION => 10; # In seconds
 
-sub new
-{
-        my $class = shift;
-        my $self = {};
-        bless($self, $class);
-        return $self;
-}
-
+# Method: _savesession
+#
 # Parameters:
 #
 #   - user name


### PR DESCRIPTION
...e2::AuthCookie subclasess

Is misleading because it tricks you in believing that you are dealing with instances when they are all class methods. (lost time yesterday because that)

 Moreover it would be positive change all the $self to $class in this packages but I don't have time to test such a change.

Very low priority
