### PR TITLE
 Removed unused method EBox::Model::DataTable::_tailoredOrder

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Removed unused method EBox::Model::DataTable::_tailoredOrder
 	+ Fixed problems calling upstart coomands from cron jobs with wrong PATH
 	+ Decode CGI unsafeParams as utf8
 	+ Avoid double encoding when printing JSON response in EBox::CGI::Base

--- a/main/core/src/EBox/Logs/Model/Details.pm
+++ b/main/core/src/EBox/Logs/Model/Details.pm
@@ -248,29 +248,6 @@ sub _totalRow
     return $self->_setValueRow( %{ $row } );
 }
 
-sub _tailoredOrder # (rows)
-{
-    my ($self, $rows) = @_;
-
-    # Sorted by sortedBy field element if it's given
-    my $fieldName = $self->sortedBy();
-    $fieldName or
-        $fieldName = 'date';
-    if (not $self->fieldHeader($fieldName) ) {
-        throw EBox::Exceptions::Internal("orderBy field $fieldName does not exist");
-    }
-
-    my $allString = __('All');
-
-    my @sortedRows = sort {
-        _compareDates($a, $b, $allString);
-    } @{$rows};
-
-
-    return \@sortedRows;
-}
-
-
 sub _compareDates
 {
     my ($a, $b, $allString) = @_;

--- a/main/core/src/EBox/Model/DataTable.pm
+++ b/main/core/src/EBox/Model/DataTable.pm
@@ -1626,41 +1626,6 @@ sub _rows
     return \@rows;
 }
 
-# Method: _tailoredOrder
-#
-#       Function to be overriden by the subclasses in order to do
-#       ordering in a different way as normal order is done.  It's
-#       functional if only if <EBox::Model::DataTable::order> is set
-#       to 0.
-#
-# Parameters:
-#
-#       rows - an array ref with the hashes with the rows to order
-#
-# Returns:
-#
-#       an array ref with the order from the current model with a
-#       hash ref of every row
-#
-sub _tailoredOrder # (rows)
-{
-    my ($self, $rows) = @_;
-
-    # Sorted by sortedBy field element if it's given
-    my $fieldName = $self->sortedBy();
-    if ( $fieldName ) {
-        if ( $self->fieldHeader($fieldName) ) {
-            my @sortedRows =
-              sort {
-                  $a->elementByName($fieldName)->cmp($b->elementByName($fieldName))
-              } @{$rows};
-            return \@sortedRows;
-        }
-    }
-    return $_[1];
-}
-
-
 # Method: setTableName
 #
 #    Use this method to set the current table name. This method

--- a/main/services/ChangeLog
+++ b/main/services/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Removed overrid of unused method EBox::Model::DataTable::_tailoredOrder
 3.0.1
 	+ Remove unique in printableName to avoid problems with i18n
 2.3.8

--- a/main/services/src/EBox/Model/ServiceTable.pm
+++ b/main/services/src/EBox/Model/ServiceTable.pm
@@ -162,23 +162,6 @@ sub _table
     return $dataTable;
 }
 
-# Method: _tailoredOrder
-#
-#        Overrides <EBox::Model::DataTable::_tailoredOrder>
-#
-sub _tailoredOrder # (rows)
-{
-    my ($self, $rows_ref) = @_;
-
-    # Order rules per priority
-    my @orderedRows = sort {
-                            $a->valueByName('name') cmp $b->valueByName('name')
-                            }
-                            @{$rows_ref};
-
-    return \@orderedRows;
-}
-
 # Method: availablePort
 #
 #	Check if a given port for a given protocol is available. That is,


### PR DESCRIPTION
This method was a leftover form an old implementation. Now _ids do the sorting by the attribute sortBy 

I remove this to avoid confusion for developers
