### PR TITLE
Silenting _getSubscriptionDetails internal exception

### DIFF
--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Silenting _getSubscriptionDetails internal exception
 	+ Fix typo in execute bundle which avoids correct installation of
 	  cloud-prof when registration is done
 3.0.13

--- a/main/remoteservices/src/EBox/RemoteServices.pm
+++ b/main/remoteservices/src/EBox/RemoteServices.pm
@@ -1750,7 +1750,7 @@ sub _getSubscriptionDetails
     if ($force or (not exists $state->{subscription}->{level})) {
         unless ($self->eBoxSubscribed()) {
             #EBox::trace();
-            throw EBox::Exceptions::Internal('Not subscribed');
+            throw EBox::Exceptions::Internal('Not subscribed', silent => 1);
         }
         my $cap = new EBox::RemoteServices::Capabilities();
         my $details;


### PR DESCRIPTION
This avoids some useless error messages when the user is not registered and goes into the dashboard.
