### PR TITLE
Dont show service certificates for removed modules

### DIFF
--- a/main/ca/ChangeLog
+++ b/main/ca/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Dont show service certificates for removed modules
 3.0.2
 	+ Adapted keys and cert downloader to the new utf8 fixes
 	+ Better error control in subject alternatives, correct subject

--- a/main/ca/src/EBox/Model/Certificates.pm
+++ b/main/ca/src/EBox/Model/Certificates.pm
@@ -127,18 +127,26 @@ sub syncRows
         $modified = 1;
     }
 
-    my %srvsFromModules = map { $_->{serviceId} => 1 } @srvs;
+    my %srvsFromModules = map { $_->{serviceId} => $_ } @srvs;
     for my $id (@{$currentRows}) {
         my $row = $self->row($id);
+
+        my $module = $row->valueByName('module');
+        if (not EBox::Global->modExists($module)) {
+            $self->removeRow($id);
+            $modified = 1;
+            next;
+        }
+
         if ($row->valueByName('enable')) {
             # already created certificates are held
             next;
         }
+
         my $serviceId = $row->valueByName('serviceId');
-        my $module = $row->valueByName('module');
         if ( not $serviceId or
-             not exists $srvsFromModules{$serviceId} or
-             not  EBox::Global->modExists($module)) {
+             not exists $srvsFromModules{$serviceId}
+            ) {
             $self->removeRow($id);
             $modified = 1;
         }


### PR DESCRIPTION
There is a risk of no-matching CN if the module is reinstalled later. However in the anterior approach (dont remove certificates of removed modules) the risk was the same if the module dependences were purged.

Since the problem with CN can happens with the two approaches, I like more to remove the certificates which is clearer for the user.  (see http://trac.zentyal.org/ticket/6014 )
