### PR TITLE
Daemon configuration files are created, as expected, in _setConf method

### DIFF
--- a/main/openvpn/ChangeLog
+++ b/main/openvpn/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Daemon configuration files are created, as expected, in _setConf method
 3.0.3
 	+ LogHelper does not sees longer 'X509NAME OK' verification status
 	  as unknown

--- a/main/openvpn/src/EBox/OpenVPN.pm
+++ b/main/openvpn/src/EBox/OpenVPN.pm
@@ -72,23 +72,23 @@ sub _create
     return $self;
 }
 
-#TODO: this method needs to be splitted in setConf and enforceServiceState
-# but right now some of the methods invoked do both configuration file
-# handling and daemon stopping/running so they need a lot of work. the only
-# drawback of doing this for now is that the hook between setConf and
-# enforceServiceState won't be useful
+# TODO: this module should use _daemons method and, if possible,
+# not to override _enforceServiceState. This was left to do when _daemons
+# and friend were added to the base modules
 sub _enforceServiceState
 {
     my ($self) = @_;
 
     $self->_cleanupDeletedDaemons();
-
     $self->initializeInterfaces();
+    $self->_doDaemon();
+}
 
+sub _setConf
+{
+    my ($self) = @_;
     $self->_writeConfFiles();
     $self->_prepareLogFiles();
-
-    $self->_doDaemon();
 }
 
 # Method: initializeInterfaces


### PR DESCRIPTION
The _enforceServiceState mess was made when _daemons, _setConf and related methods were introduced. OpenVPN back the nwas particualr because it was the only module with a variable number of daemons, so instead of adapting it fully to the new framework all the daemon and configuration stuf was crammed instead _enforceServiceState.

It is left to be done make use of the _deamons methods.
