### PR TITLE
Bridged interfaces added to auto directive in  /etc/networks/interfaces ...

### DIFF
--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Bridged interfaces added to 'auto' directive in
+	  /etc/networks/interfaces to avoid network startup problems
 	+ Dont allow to set a local address as network proxy
 	+ Fixed error in json response trigered by widget size
 3.0.2

--- a/main/network/src/EBox/Network.pm
+++ b/main/network/src/EBox/Network.pm
@@ -2862,10 +2862,13 @@ sub generateInterfaces
     open(IFACES, ">", $tmpfile) or
         throw EBox::Exceptions::Internal("Could not write on $file");
     print IFACES "auto lo";
-    foreach (@{$iflist}) {
-        if (($self->ifaceMethod($_) eq 'static') or
-            ($self->ifaceMethod($_) eq 'dhcp')) {
-            print IFACES " " . $_;
+    foreach my $iface (@{$iflist}) {
+        my $ifMethod = $self->ifaceMethod($iface);
+        if (($ifMethod eq 'static') or
+            ($ifMethod eq 'dhcp') or
+            ($ifMethod eq 'bridged')
+        ) {
+            print IFACES " " . $iface;
         }
     }
 


### PR DESCRIPTION
...to avoid network startup problems

A couple of people has reported failures for this and since it does not break no-problematic setups we can include it
