### PR TITLE
Update total ticks dynamically in progress indicator if ticks overflow

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Update total ticks dynamically in progress indicator if ticks overflow
 3.0.16
 	+ Fixed regression in boolean in-place edit with Union types
 	+ Added some missing timezones to EBox::Types::TimeZone

--- a/main/core/src/EBox/ProgressIndicator.pm
+++ b/main/core/src/EBox/ProgressIndicator.pm
@@ -98,6 +98,17 @@ sub notifyTick
 
     my $ticks = $self->_get('ticks');
     $ticks += $nTicks;
+
+    my $totalTicks = $self->totalTicks();
+    my $changedTotal = 0;
+    while ($totalTicks < $ticks) {
+        $totalTicks += 5;
+        $changedTotal = 1;
+    }
+
+    if ($changedTotal) {
+        $self->setTotalTicks($totalTicks);
+    }
     $self->_set('ticks', $ticks);
 }
 
@@ -244,6 +255,12 @@ sub setAsFinished
 
     if (defined($errorMsg)) {
         $self->_set('errorMsg', $errorMsg);
+    }
+
+    my $ticks = $self->ticks();
+    my $totalTicks = $self->totalTicks();
+    if ($ticks != $totalTicks) {
+        $self->_set('ticks', $totalTicks);
     }
 }
 


### PR DESCRIPTION
I have tested it with backup progress, modifying the notifyTick method to add 8 extra ticks without problems.
