### PR TITLE
Remove filesync upstart file

### DIFF
--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,5 +1,7 @@
 HEAD
-	+ Force mode when writing QA apt ocnfiguration file
+	+ Remove filesync upstart file as it is not longer maintained by
+	  this package
+	+ Force mode when writing QA apt configuration file
 	+ Avoid exception in subscription info table when a
 	  no subscribed server use no-ascii character set
 3.0.14

--- a/main/remoteservices/debian/precise/zentyal.filesync.upstart
+++ b/main/remoteservices/debian/precise/zentyal.filesync.upstart
@@ -1,9 +1,0 @@
-# Zentyal files sync daemon
-#
-#
-
-description     "Zentyal Files Sync daemon"
-author          "eBox Technologies S.L."
-
-respawn
-exec zentyal-files-sync /var/lib/zentyal/conf/filesync/sync.conf >> /var/log/zentyal/filesync.log


### PR DESCRIPTION
- Remove filesync upstart file as it is not longer maintained by
  this package
