### PR TITLE
Avoid not numeric warning in hash size comparation during provision

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Avoid not numeric warning in hash size comparation during provision
 	+ Allow user names composed only of digits
 	+ Do not add firewall rules to loopback interface
 	+ Improve checks when upgrading from 3.0.11 to 3.0.12

--- a/main/samba/src/EBox/Samba/Provision.pm
+++ b/main/samba/src/EBox/Samba/Provision.pm
@@ -216,7 +216,7 @@ sub _domainsIP
         }
     }
 
-    if (%domainsIp == 0) {
+    if ((keys %domainsIp) == 0) {
         $samba->enableService(0);
         my $domain = $domainRow->valueByName('domain');
         my $domainIpUrl = '/DNS/View/DomainIpTable?directory=DomainTable/keys/' .


### PR DESCRIPTION
However the behaviour of code was correct because we checked for zero, and scalar value of a empty hash is zero
