### PR TITLE
2.2 core: Added missing pre-save and post-save directories

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Added missing pre-save and post-save directories
 2.2.8
 	+ Table search control allows utf8 and all characters
 	+ Fixed bug that made that the lock was shared between owners

--- a/main/core/conf/post-save/README
+++ b/main/core/conf/post-save/README
@@ -1,0 +1,3 @@
+Any file added in this dir will be executed after Zentyal saves the changes.
+
+Remember to give execution permissions to your scripts with chmod +x

--- a/main/core/conf/pre-save/README
+++ b/main/core/conf/pre-save/README
@@ -1,0 +1,3 @@
+Any file added in this dir will be executed before Zentyal saves the changes.
+
+Remember to give execution permissions to your scripts with chmod +x


### PR DESCRIPTION
I have serious trouble with zentyal-package so I cannot build the deb to test it.

However this should be fix, but it need the build package check to be sure that the /etc/zentyal/pre-save and /etc/zentyal/post-save are created or keep.

See http://forum.zentyal.org/index.php?topic=14818.new for more information
