### PR TITLE
Disable reverse DNS lookups for msktutil commands and explicitly set the DC

### DIFF
--- a/main/squid/ChangeLog
+++ b/main/squid/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Disable DC reverse DNS lookup for msktutil commands
+	+ Explicitly set the DC for msktutil command when updating the keytab
 	+ Regenerate Kerberos keytab on LDAP reprovision
 3.0.7
 	+ Fixed bug which returned the list of users of a profile inside

--- a/main/squid/src/EBox/Squid.pm
+++ b/main/squid/src/EBox/Squid.pm
@@ -827,17 +827,17 @@ sub _setAuthenticationModeAD
             EBox::Sudo::root("cp " . KEYTAB_FILE . " $keytabTempPath");
             EBox::Sudo::root("chown ebox $keytabTempPath");
             # Update keytab
-            my $cmd = "msktutil --auto-update --verbose --computer-name '$computerName' --keytab '$keytabTempPath'";
+            my $cmd = "msktutil -N --auto-update --computer-name '$computerName' --keytab '$keytabTempPath' --server '$dc' --user-creds-only --verbose";
             EBox::Sudo::command($cmd);
             # Move keytab to the correct place
             EBox::Sudo::root("mv $keytabTempPath " . KEYTAB_FILE);
         } else {
             # Create the account and extract keytab to temporary directory
             EBox::Sudo::command("rm -f $keytabTempPath");
-            my $cmd = "msktutil -c -b 'CN=COMPUTERS' -s 'HTTP/$hostFQDN' " .
+            my $cmd = "msktutil -N -c -b 'CN=COMPUTERS' -s 'HTTP/$hostFQDN' " .
                       "-k '$keytabTempPath' --computer-name '$computerName' " .
-                      "--upn 'HTTP/$hostFQDN' --server '$dc' --verbose " .
-                      "--user-creds-only";
+                      "--upn 'HTTP/$hostFQDN' --server '$dc' --user-creds-only " .
+                      "--verbose";
             EBox::Sudo::command($cmd);
 
             # Move keytab to the correct place


### PR DESCRIPTION
We have found some scenarios where although the AD DNS is properly configured, the msktutil tool fails to execute. This pull request disables the msktutil reverse lookups and set explicitly the DC to use in all circumstances.
