### PR TITLE
Fix UsersSync by retrieving global instance correctly

### DIFF
--- a/main/users/src/EBox/UsersSync/Master.pm
+++ b/main/users/src/EBox/UsersSync/Master.pm
@@ -301,7 +301,7 @@ sub _recreateLDAP
     $users->enableActions();
 
     # LDAP modules should reconfigure themselves for its slave role
-    my $global = $self->global();
+    my $global = EBox::Global->getInstance();
     my @mods = @{ $global->sortModulesByDependencies($global->modInstances(), 'depends' ) };
     foreach my $mod (@mods) {
         if (not $mod->isa('EBox::LdapModule')) {


### PR DESCRIPTION
The UsersSync Master class does not have a base class which provides
the global() function which results in the following error when trying
to sync users from a master:

ERROR> GlobalImpl.pm:641 EBox::GlobalImpl::**ANON** - Failed to save
changes in module users: Can't locate object method "global" via package
"EBox::UsersSync::Master" at /usr/share/perl5/EBox/UsersSync/Master.pm
line 304.

We therefore need to get the global instance via EBox::Global.
