### PR TITLE
Setup filesystem now writes a valid fstab file event when the filesystem...

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Setup filesystem now writes a valid fstab file event when the filesystem has
+	  not any mount option
 	+ Clearer error messages when EBox::LDB::safeConnect fails
 	+ Raise exception if during the provision either the domain
 	  administrator user or the domain administrator group are

--- a/main/samba/src/scripts/setup-filesystem
+++ b/main/samba/src/scripts/setup-filesystem
@@ -16,7 +16,10 @@ for my $line (@fstab) {
     # Mount fs with xattr and acl
     if ($fields[2] =~ /^(ext3|ext4)$/) {
         unless ($fields[3] =~ /acl/) {
-            $fields[3] .= ',acl';
+            if ($fields[3]) {
+                $fields[3] .= ',';
+            }
+            $fields[3] .= 'acl';
             $modified = 1;
         }
         unless ($fields[3] =~ /user_xattr/) {


### PR DESCRIPTION
... has not any mount option.

This error is very infrequent, so low priority
See http://trac.zentyal.org/ticket/6423
