### PR TITLE
Silent diff in EBox::Types::File::isEqualTo

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Silent diff in EBox::Types::File::isEqualTo
 	+ Proper link to remote in configuration backup page
 3.0.19
 	+ Removed full restore option for restore-backup tool and

--- a/main/core/src/EBox/Types/File.pm
+++ b/main/core/src/EBox/Types/File.pm
@@ -124,13 +124,13 @@ sub isEqualTo
         my $tmpPath = $new->tmpPath;
         my $equal;
         try {
-            EBox::Sudo::root("diff -q $path $tmpPath");
+            EBox::Sudo::silentRoot("diff -q $path $tmpPath");
             # diff return value 0; they are equal
             $equal = 1;
         }
         otherwise {
-            # diff command failed, we assume that they ar different (cannot find
-            # a reliable docuentation of diff's return values)
+            # diff command failed, we assume they are different (cannot find
+            # a reliable documentation of diff command's return values)
             $equal = 0;
 
         };


### PR DESCRIPTION
Remove this unpleasant error:

2013/04/25 01:39:08 ERROR> Sudo.pm:234 EBox::Sudo::_rootError - root command diff -q /var/lib/zentyal/files/squid/archives/Zentyal_security_updates /var/lib/zentyal/tmp/fileList_path failed.
