### PR TITLE
 Migration to remove any letfover need_reprovision key in  read_only tre...

### DIFF
--- a/main/users/ChangeLog
+++ b/main/users/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Migration to remove any letfover need_reprovision key in
+	  read_only tree
 3.0.16
 	+ Assure that we don't have a phantom need_reprovision key in
 	  read-only tree

--- a/main/users/src/EBox/UsersAndGroups.pm
+++ b/main/users/src/EBox/UsersAndGroups.pm
@@ -268,6 +268,14 @@ sub initialSetup
             }
         }
     }
+    if (defined ($version) and (EBox::Util::Version::compare($version, '3.0.17') < 0)) {
+        if (not $self->get('need_reprovision')) {
+            # previous versions could left a leftover ro/need_reprovision which
+            # could force reprovision on reboot
+            my $roKey = 'users/ro/need_reprovision';
+            $self->redis->unset($roKey);
+        }
+    }
 
     # Execute initial-setup script
     $self->SUPER::initialSetup($version);
@@ -521,7 +529,7 @@ sub _setConf
 
     if ($self->get('need_reprovision')) {
         $self->unset('need_reprovision');
-        # workaround to be sure that we don't let a orphan need_reprovision on read-only
+        # workaround  a orphan need_reprovision on read-only
         my $roKey = 'users/ro/need_reprovision';
         $self->redis->unset($roKey);
         $self->reprovision();


### PR DESCRIPTION
...e

This is important because any server with the leftover need_reprovision key in readonly will trigger a reprovision in its next reboot; wiping out all LDAP data
