### PR TITLE
Fix NFQUEUE clashing with l7filter from trafficshaping module

### DIFF
--- a/main/ips/ChangeLog
+++ b/main/ips/ChangeLog
@@ -1,2 +1,4 @@
+HEAD
+	+ Fix NFQUEUE clashing with l7filter in trafficshaping module
 3.0
 	+ Initial release

--- a/main/ips/src/EBox/IPS/FirewallHelper.pm
+++ b/main/ips/src/EBox/IPS/FirewallHelper.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 eBox Technologies S.L.
+# Copyright (C) 2013 Zentyal S.L.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2, as
@@ -41,9 +41,10 @@ sub _ifaceRules
     my @rules;
 
     my $ips = EBox::Global->modInstance('ips');
+    my $qNum = $ips->nfQueueNum();
 
     foreach my $iface (@{$ips->enabledIfaces()}) {
-        push (@rules, "-i $iface -m mark ! --mark 0x10000/0x10000 -j NFQUEUE");
+        push (@rules, "-i $iface -m mark ! --mark 0x10000/0x10000 -j NFQUEUE --queue-num $qNum");
     }
 
     return \@rules;

--- a/main/ips/stubs/suricata.upstart.mas
+++ b/main/ips/stubs/suricata.upstart.mas
@@ -1,6 +1,9 @@
+<%args>
+  $nfQueueNum
+</%args>
 pre-start script
     /etc/init.d/suricata stop || true
 end script
 
-exec /usr/bin/suricata -c /etc/suricata/suricata-debian.yaml -q 0
+exec /usr/bin/suricata -c /etc/suricata/suricata-debian.yaml -q <% $nfQueueNum %>
 respawn


### PR DESCRIPTION
Fix a security issue when running l7filter along with suricata in same host.
