### PR TITLE
Fixed graph template so it could be feed with data using decimal  comma,...

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Fixed graph template so it could be feed with data using decimal
+	  comma, it will convert it to a JS array without problems
 3.0.20
 	+ Check against inexistent path in EBox::Util::SHM::subkeys
 	+ Silent diff in EBox::Types::File::isEqualTo

--- a/main/core/src/templates/graph.mas
+++ b/main/core/src/templates/graph.mas
@@ -75,6 +75,9 @@ Flotr.draw(
         data: [
 %   for my $i (0..$#{$data}) {
 %       my $pair = $data->[$i];
+%#      internationalized value could have decimal comma
+%       $pair->[0] =~ s/,/./;
+%       $pair->[1] =~ s/,/./;
 %       if ($pair->[1] ne 'nan') {
 %           if (!defined($min_y) or ($min_y > $pair->[1])) {
 %               $min_y = $pair->[1];


### PR DESCRIPTION
... it will convert it to a JS array without problems.

This is important because otherwise monitor is broken for all locals with decimal point.

Also forwardport it to 3.1
