### PR TITLE
Added CUPS and ftp to Safe_ports

### DIFF
--- a/main/squid/ChangeLog
+++ b/main/squid/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Added ftp and CUPS to SSL_ports, as these ports are likely to be 
+	  using CONNECT Method
 3.1.1
 	+ Squid time ACLs have independient ids, this fixes several issues
 	  with combinations of time, dates and long acls

--- a/main/squid/stubs/squid-external.conf.mas
+++ b/main/squid/stubs/squid-external.conf.mas
@@ -232,6 +232,8 @@ acl to_localhost dst 127.0.0.0/8 ::1
 acl manager url_regex -i ^cache_object:// +i ^https?://[^/]+/squid-internal-mgr/
 acl SSL_ports port 443          # https, snews
 acl SSL_ports port 873		    # rsync
+acl SSL_ports port 21
+acl SSL_ports port 631
 acl Safe_ports port 80          # http
 acl Safe_ports port 21          # ftp
 acl Safe_ports port 443 563	    # https, snews


### PR DESCRIPTION
I think we should include these ports onto Safe_ports per default, given they are included as Safe ports, and most ftp clients will use http connect when proxied, and it is a common practice to allow web cups interface to be reached only with https (CONNECT method again)
