### PR TITLE
 	Added CUPS and ftp to Safe_ports

### DIFF
--- a/main/squid/ChangeLog
+++ b/main/squid/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Added CUPS and ftp to Safe_ports 
 	+ Avoid warning in AccessRules validateTypedRow
 3.1.1
 	+ Squid time ACLs have independient ids, this fixes several issues

--- a/main/squid/stubs/squid-external.conf.mas
+++ b/main/squid/stubs/squid-external.conf.mas
@@ -232,6 +232,8 @@ acl to_localhost dst 127.0.0.0/8 ::1
 acl manager url_regex -i ^cache_object:// +i ^https?://[^/]+/squid-internal-mgr/
 acl SSL_ports port 443          # https, snews
 acl SSL_ports port 873		    # rsync
+acl SSL_ports port 21		#ftp
+acl SSL_ports port 631		#cups over https
 acl Safe_ports port 80          # http
 acl Safe_ports port 21          # ftp
 acl Safe_ports port 443 563	    # https, snews


### PR DESCRIPTION
I think we should include these ports onto Safe_ports per default, given they are included as Safe ports, and most ftp clients will use http connect when proxied, and it is a common practice to allow web cups interface to be reached only with https (CONNECT method again)
