### PR TITLE
Redirect to / from /ebox using remote access to avoid blank page

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Redirect to / from /ebox using remote access to avoid blank page
 	+ Make manage administrators table resilent against invalid users
 3.0.21
 	+ Added EBox::Types::URI type

--- a/main/core/src/EBox/Auth.pm
+++ b/main/core/src/EBox/Auth.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2008-2012 eBox Technologies S.L.
+# Copyright (C) 2008-2013 eBox Technologies S.L.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2, as
@@ -231,7 +231,12 @@ sub loginCC
     my ($self, $req) = @_;
 
     if ( $self->recognize_user($req) == OK ) {
-        return $self->authenticate($req);
+        my $retVal = $self->authenticate($req);
+        if ($req->uri() =~ m:^/ebox:) {
+            $req->headers_out()->set('Location' => '/');
+            return HTTP_MOVED_TEMPORARILY;
+        }
+        return $retVal;
     } else {
         if ( EBox::Global->modExists('remoteservices') ) {
             my $remoteServMod = EBox::Global->modInstance('remoteservices');


### PR DESCRIPTION
- This happens as /ebox does nothing when the user is already identified.
- Redirect to / when this happens
