### PR TITLE
Use krb5 keys on new users when plain password not available

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Use krb5 keys on new users when plain password not available
 3.0.20
 	+ Fix SIDs to ignore list, add missing end of line character in regular
 	  expressions

--- a/main/samba/src/EBox/SambaLdapUser.pm
+++ b/main/samba/src/EBox/SambaLdapUser.pm
@@ -113,7 +113,12 @@ sub _addUser
     my $uidNumber = $sambaUser->get('uidNumber');
 
     EBox::info("Setting '$samAccountName' password");
-    $sambaUser->changePassword($zentyalPassword);
+    if (defined($zentyalPassword)) {
+        $sambaUser->changePassword($zentyalPassword);
+    } else {
+        my $keys = $zentyalUser->kerberosKeys();
+        $sambaUser->setCredentials($keys);
+    }
 
     if ($uidNumber) {
         $sambaUser->setupUidMapping($uidNumber);


### PR DESCRIPTION
Please @kernevil take a look and give us a :+1: before merging
