### PR TITLE
Better check for ipv6 presence before disabling it

### DIFF
--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Better check for ipv6 presence before disabling it
 	+ Adapted DNS resolver model to authorization mode changes
 	  in users and squid module
 3.1.2

--- a/main/network/src/EBox/Network.pm
+++ b/main/network/src/EBox/Network.pm
@@ -243,7 +243,7 @@ sub enableActions
     my ($self) = @_;
 
     # Disable IPv6 if it is enabled
-    if (-e '/proc/net/if_inet6') {
+    if (-d  '/proc/sys/net/ipv6') {
         my @cmds;
         push (@cmds, 'sed -ri "/net\.ipv6\.conf\.all\.disable_ipv6/d" ' . SYSCTL_FILE);
         push (@cmds, 'sed -ri "/net\.ipv6\.conf\.default\.disable_ipv6/d" ' . SYSCTL_FILE);


### PR DESCRIPTION
I think this is a better way to check for ipv6 than the previous one. See http://trac.zentyal.org/ticket/6910 for a example of a failure with the previous way.

What do you think?
