### PR TITLE
Fixed encoding of parameters in confirmation dialogs

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fixed encoding of parameters in confirmation dialogs
 	+ Check backup integrity by listing the tar file, throw
 	  InvalidData exception if the tar is corrupted
 3.0.22

--- a/main/core/www/js/table-helper.js
+++ b/main/core/www/js/table-helper.js
@@ -107,9 +107,6 @@ function encodeFields(table, fields)
     return pars.join('&');
 }
 
-
-
-
 function modalAddNewRow(url, table, fields, directory,  nextPage, extraParams)
 {
     var title = '';
@@ -1166,7 +1163,7 @@ function confirmationDialog(url, table, directory, actionToConfirm, elements)
     var id = table + '_' + name;
     var el = $(id);
     pars +='&'+ name + '=';
-    pars +=el.value;
+    pars +=  encodeURIComponent(el.value);
   }
 
   var request = new Ajax.Request(url, {


### PR DESCRIPTION
- This also affects 3.1 but it seems that jQuery has sanitized itself the input. Merge nonetheless.
