### PR TITLE
Remove FirewallObserver inheritance as it is not used

### DIFF
--- a/main/radius/ChangeLog
+++ b/main/radius/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Remove FirewallObserver inheritance as it is not used
 3.0.2
 	+ Adapted to changes in EBox::LogHelper::_convertTimestamp
 3.0.1

--- a/main/radius/src/EBox/Radius.pm
+++ b/main/radius/src/EBox/Radius.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 
 package EBox::Radius;
-use base qw(EBox::Module::Service EBox::FirewallObserver EBox::LogObserver);
+use base qw(EBox::Module::Service EBox::LogObserver);
 
 use EBox::Global;
 use EBox::Gettext;


### PR DESCRIPTION
It gives some problems if fw helper is not defined in some core parts.

Faster firewall code now :)

Spotted by @jbahillo . Thanks!
