### PR TITLE
OUs are not using CN but ou field and has no restriction on valid charac...

### DIFF
--- a/main/users/src/EBox/Users/OU.pm
+++ b/main/users/src/EBox/Users/OU.pm
@@ -84,8 +84,6 @@ sub create
 
     my $usersMod = EBox::Global->modInstance('users');
 
-    $usersMod->checkCnLimitations($args{name}) or
-        throw EBox::Exceptions::InvalidData(data => 'name', value => $args{name});
     $args{parent} or
         throw EBox::Exceptions::MissingArgument('parent');
     $args{parent}->isContainer() or


### PR DESCRIPTION
...ters

From what I saw at http://support.microsoft.com/kb/909264 OUs names have no restriction on the characters used for its name (ou field) so is a bug to apply the same restrictions a CN has. This should fix the problem when activating zentyal-mail. I didn't run anste for this change because my laptop is busy testing another branch and I think this change is safe to merge.
