### PR TITLE
 More clear messages for gateway not reachable condition

### DIFF
--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ More clear messages for gateway not reachable condition
 	+ Fix regression is Gateways table due to the change of behaviour
 	  of update row notifications
 	+ Added menu icon

--- a/main/network/src/EBox/Network.pm
+++ b/main/network/src/EBox/Network.pm
@@ -3524,11 +3524,11 @@ sub gatewayReachable
     if ($name) {
         if (not $reachableByNoStaticIface) {
         throw EBox::Exceptions::External(
-                __x("Gateway {gw} not reachable", gw => $gw));
+                __x("Gateway {gw} must be in the same network than a static interface", gw => $gw));
         } else {
         throw EBox::Exceptions::External(
-                __x("Gateway {gw} must be reachable by a static interface. "
-                    . "Currently it is reachable by {iface} which is not static",
+                __x("Gateway {gw} must be in the same network than a static interface. "
+                    . "Currently it belongs to the network of {iface} which is not static",
                     gw => $gw, iface => $reachableByNoStaticIface) );
         }
 

--- a/main/network/src/EBox/Network/Model/GatewayTable.pm
+++ b/main/network/src/EBox/Network/Model/GatewayTable.pm
@@ -285,9 +285,9 @@ sub validateRow
                 if ($action eq 'add') {
                     throw EBox::Exceptions::External(__('You can not manually add a gateway for DHCP or PPPoE interfaces'));
                 } else {
-                    throw EBox::Exceptions::External(__x("Gateway {gw} must be reachable by a static interface. "
-                                . "Currently it is reachable by {iface} which is not static",
-                                gw => $ip, iface => $iface));
+                    throw EBox::Exceptions::External(__x("Gateway {gw} must be in the same network that a static interface. "
+                                                          . "Currently it belongs to the network of {iface} which is not static",
+                                                         gw => $ip, iface => $iface));
                 }
             }
         } else {


### PR DESCRIPTION
The reason for this is for 'reachable' normally it is understood that it needs connectivity, like being reachable by the ping command. But what we want is that the gateway will be in the same network that one of our static interfaces
