### PR TITLE
Fix firewall logging

### DIFF
--- a/main/firewall/ChangeLog
+++ b/main/firewall/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Use common prefix (zentyal-firewall) for logging redirections,
+	  snat, drop and log rules
 	+ Use (i|f|o)accept chains in user's defined firewall rules to be
 	  able to analyse the traffic
 	+ Fix regression (INVALID packets on FORWARD were accepted)

--- a/main/firewall/src/EBox/Firewall/IptablesRule/SNAT.pm
+++ b/main/firewall/src/EBox/Firewall/IptablesRule/SNAT.pm
@@ -96,7 +96,7 @@ sub strings
                         "--limit $limit/min ".
                         "--limit-burst $burst " .
                         '--log-level ' . $self->{'log_level'} . ' ' .
-                        '--log-prefix "ebox-firewall snat "';
+                        '--log-prefix "zentyal-firewall snat "';
 
                     unshift (@rules, $logRule);
                 }

--- a/main/firewall/src/EBox/FirewallLogHelper.pm
+++ b/main/firewall/src/EBox/FirewallLogHelper.pm
@@ -61,7 +61,7 @@ sub processLine # (file, line, logger)
 {
     my ($self, $file, $line, $dbengine) = @_;
 
-    unless ($line =~ /^(\w+\s+\d+ \d\d:\d\d:\d\d) .*: \[.*\] ebox-firewall (\w+) (.+)/) {
+    unless ($line =~ /^(\w+\s+\d+ \d\d:\d\d:\d\d) .*: \[.*\] zentyal-firewall (\w+) (.+)/) {
         return;
     }
     my $date = $1 . ' ' . (${[localtime(time)]}[5] + 1900);

--- a/main/firewall/src/EBox/Iptables.pm
+++ b/main/firewall/src/EBox/Iptables.pm
@@ -932,7 +932,7 @@ sub _drop
             pf("-I drop -j LOG -m limit --limit $limit/min " .
             "--limit-burst $burst" .
             ' --log-level ' . SYSLOG_LEVEL .
-            ' --log-prefix "ebox-firewall drop "')
+            ' --log-prefix "zentyal-firewall drop "')
         );
     }
     return \@commands;
@@ -969,7 +969,7 @@ sub _log
             pf("-I log -j LOG -m limit --limit $limit/min " .
             "--limit-burst $burst" .
             ' --log-level ' . SYSLOG_LEVEL .
-            ' --log-prefix "ebox-firewall log "')
+            ' --log-prefix "zentyal-firewall log "')
         );
     }
     return \@commands;

--- a/main/firewall/src/EBox/t/FirewallLogHelper.t
+++ b/main/firewall/src/EBox/t/FirewallLogHelper.t
@@ -20,7 +20,7 @@ package EBox::FirewallLogHelper::Test;
 
 use base 'Test::Class';
 
-use Test::More tests => 7;
+use Test::More tests => 16;
 use Test::MockObject;
 use Test::Exception;
 use Test::Differences;
@@ -68,7 +68,7 @@ sub test_drop : Test(6)
     my @cases = (
         {
             line =>
-              'Jan 25 11:14:44 macostaserver kernel: [2470652.110434] ebox-firewall drop IN=eth1 OUT= MAC=ff:ff:ff:ff:ff:ff:40:4a:03:82:33:14:08:00 SRC=192.168.1.254 DST=192.168.1.255 LEN=72 TOS=0x00 PREC=0x00 TTL=1 ID=25998 PROTO=UDP SPT=520 DPT=520 LEN=52 MARK=0x1',
+              'Jan 25 11:14:44 macostaserver kernel: [2470652.110434] zentyal-firewall drop IN=eth1 OUT= MAC=ff:ff:ff:ff:ff:ff:40:4a:03:82:33:14:08:00 SRC=192.168.1.254 DST=192.168.1.255 LEN=72 TOS=0x00 PREC=0x00 TTL=1 ID=25998 PROTO=UDP SPT=520 DPT=520 LEN=52 MARK=0x1',
             expected => {
                 timestamp => '2013-01-25 11:14:44',
                 event => 'drop',
@@ -84,7 +84,7 @@ sub test_drop : Test(6)
         },
         {
             line =>
-              'Jan 25 11:14:52 macostaserver kernel: [2470659.768645] ebox-firewall drop IN=tap0 OUT= MAC= SRC=192.168.160.1 DST=192.168.160.255 LEN=271 TOS=0x00 PREC=0x00 TTL=64 ID=0 DF PROTO=UDP SPT=631 DPT=631 LEN=251 MARK=0x1',
+              'Jan 25 11:14:52 macostaserver kernel: [2470659.768645] zentyal-firewall drop IN=tap0 OUT= MAC= SRC=192.168.160.1 DST=192.168.160.255 LEN=271 TOS=0x00 PREC=0x00 TTL=64 ID=0 DF PROTO=UDP SPT=631 DPT=631 LEN=251 MARK=0x1',
             expected => {
                 timestamp => '2013-01-25 11:14:52',
                 event => 'drop',
@@ -98,6 +98,70 @@ sub test_drop : Test(6)
             },
             file => '/var/log/syslog',
         }
+       );
+    $self->_testCases(\@cases);
+}
+
+sub test_redirect : Test(6)
+{
+    my ($self) = @_;
+
+    my @cases = (
+        {
+            line => 'Sep 10 17:54:12 macostaserver kernel: [913784.855409] zentyal-firewall redirect IN=eth0 OUT=eth2 MAC=aa:ed:fc:ec:88:41:00:20:6f:1f:c0:41:08:00 SRC=77.163.8.2 DST=172.31.3.1 LEN=64 TOS=0x00 PREC=0x00 TTL=56 ID=13836 DF PROTO=TCP SPT=54669 DPT=443 WINDOW=65535 RES=0x00 SYN URGP=0 MARK=0x1',
+            expected => {
+                timestamp => '2013-09-10 17:54:12',
+                event     => 'redirect',
+                fw_in     => 'eth0',
+                fw_out    => 'eth2',
+                fw_proto  => 'TCP',
+                fw_src    => '77.163.8.2',
+                fw_spt    => 54669,
+                fw_dst    => '172.31.3.1',
+                fw_dpt    => 443,
+            },
+            file => '/var/log/syslog',
+        },
+        {
+            line => 'Sep 10 17:56:48 macostaserver kernel: [913940.939865] zentyal-firewall redirect IN=eth0 OUT=eth1 MAC=ad:ac:ef:ed:98:42:00:10:6f:1f:c0:41:08:00 SRC=77.74.9.6 DST=172.16.21.42 LEN=60 TOS=0x00 PREC=0x00 TTL=54 ID=26544 DF PROTO=TCP SPT=34571 DPT=80 WINDOW=5840 RES=0x00 SYN URGP=0 MARK=0x1',
+            expected => {
+                timestamp => '2013-09-10 17:56:48',
+                event     => 'redirect',
+                fw_in     => 'eth0',
+                fw_out    => 'eth1',
+                fw_proto  => 'TCP',
+                fw_src    => '77.74.9.6',
+                fw_spt    => 34571,
+                fw_dst    => '172.16.21.42',
+                fw_dpt    => 80,
+            },
+            file => '/var/log/syslog',
+        },
+
+       );
+    $self->_testCases(\@cases);
+}
+
+sub test_log : Test(3)
+{
+    my ($self) = @_;
+
+    my @cases = (
+        {
+            line => 'Sep 12 16:25:11 macostaserver kernel: [ 1661.128397] zentyal-firewall log IN=eth1 OUT= MAC=08:00:27:ee:e4:79:0a:00:27:00:00:00:08:00 SRC=192.168.56.1 DST=192.168.56.101 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=63662 DF PROTO=TCP SPT=38115 DPT=22 WINDOW=14600 RES=0x00 SYN URGP=0 MARK=0x10001',
+            expected => {
+                timestamp => '2013-09-12 16:25:11',
+                event     => 'log',
+                fw_in     => 'eth1',
+                fw_out    => undef,
+                fw_proto  => 'TCP',
+                fw_src    => '192.168.56.1',
+                fw_spt    => 38115,
+                fw_dst    => '192.168.56.101',
+                fw_dpt    => 22,
+            },
+            file => '/var/log/syslog',
+        },
        );
     $self->_testCases(\@cases);
 }


### PR DESCRIPTION
- Use common prefix (zentyal-firewall) for logging redirections, snat, drop and log rules 
