### PR TITLE
Fix typo in setSecurityGroup when no GID is set yet

### DIFF
--- a/main/users/ChangeLog
+++ b/main/users/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fix typo in setSecurityGroup when no GID is set yet
 	+ Show group in slave as read-only
 	+ Show in a slave when the user is not a member of any group
 	+ Check email address for a group is done

--- a/main/users/src/EBox/Users/CGI/EditGroup.pm
+++ b/main/users/src/EBox/Users/CGI/EditGroup.pm
@@ -69,7 +69,7 @@ sub _process
         $self->_requireParam('type', __('type'));
 
         my $type = $self->param('type');
-        $group->setSecurityGroup($type eq 'security');
+        $group->setSecurityGroup(($type eq 'security'), 1);
 
         my $description = $self->unsafeParam('description');
         if (length ($description)) {

--- a/main/users/src/EBox/Users/Group.pm
+++ b/main/users/src/EBox/Users/Group.pm
@@ -645,7 +645,7 @@ sub setSecurityGroup
         unless (defined $self->get('gidNumber')) {
             my $gid = $self->_gidForNewGroup();
             $self->_checkGid($gid);
-            self->set('gidNumber', $gid, $lazy);
+            $self->set('gidNumber', $gid, $lazy);
         }
         $self->add('objectClass', 'posixGroup', $lazy);
     } else {


### PR DESCRIPTION
Likewise other attributes, set security group as lazy in CGI
