### PR TITLE
Clean /var/lib/zentyal/tmp at the first moments of boot

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,7 @@
 HEAD
+	+ Clean /var/lib/zentyal/tmp at the first moments of boot instead of
+	  when running zentyal start, this fixes problems with leftover locks
+	  that affect dhclient hooks
 	+ Set audit after logs when enabling in first install
 	+ Avoid getting unsaved changes by using readonly instance in manage-logs
 3.1.11

--- a/main/core/debian/precise/zentyal.cleantmp.upstart
+++ b/main/core/debian/precise/zentyal.cleantmp.upstart
@@ -1,0 +1,7 @@
+description "Clean Zentyal temp directory"
+
+start on filesystem
+
+task
+
+exec /bin/rm -rf /var/lib/zentyal/tmp/*

--- a/main/core/src/EBox/Util/Init.pm
+++ b/main/core/src/EBox/Util/Init.pm
@@ -25,14 +25,6 @@ use EBox::ServiceManager;
 use File::Slurp;
 use Error qw(:try);
 
-sub cleanTmpOnBoot
-{
-    if (not exists $ENV{'USER'}) {
-        my $tmpdir = EBox::Config::tmp();
-        EBox::Sudo::root("rm -rf $tmpdir/*");
-    }
-}
-
 sub moduleList
 {
     print "Module list: \n";

--- a/main/core/src/scripts/zentyal.init.d
+++ b/main/core/src/scripts/zentyal.init.d
@@ -28,7 +28,6 @@ sub main
 {
     if (@ARGV == 1) {
         if ($ARGV[0] eq 'start') {
-            EBox::Util::Init::cleanTmpOnBoot();
             EBox::Util::Init::start();
             EBox::Sudo::root('initctl emit zentyal-started');
         }


### PR DESCRIPTION
Instead of when running zentyal start, this fixes problems with leftover locks
that affect dhclient hooks
