### PR TITLE
Cperello/fix ipsec status

### DIFF
--- a/main/ipsec/ChangeLog
+++ b/main/ipsec/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Removed ipsec_setup.pid from the list of pids related with ipsec because
+	  it doesn't need to be running all the time.
 2.2.1
 	+ Added ipsec_setup.pid to the list of pids related with ipsec.
 	+ Deleted confkey copied from VPN module

--- a/main/ipsec/src/EBox/IPsec.pm
+++ b/main/ipsec/src/EBox/IPsec.pm
@@ -118,7 +118,6 @@ sub _daemons
             'type' => 'init.d',
             'pidfiles' => [
                 '/var/run/pluto/pluto.pid',
-                '/var/run/pluto/ipsec_setup.pid',
             ],
         }
     ];


### PR DESCRIPTION
With the previous fix, I added a pid file but it's running all the time, so now, we get on the dashboard the message that ipsec is not running just because that non persistent process. Support team request me to do this so it should join the QA process...
