### PR TITLE
Make Zarafa SSO work with webaccess and virtual host

### DIFF
--- a/main/zarafa/ChangeLog
+++ b/main/zarafa/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Disable Single Sign-On on webapp as it is not working and undocumented
+	+ Make Single Sign-On work on webaccess using only a virtual host
 3.0.3
 	+ Change the kerberos service from zarafa to http. Zarafa and Squid must
 	  share the service principal.

--- a/main/zarafa/src/EBox/Zarafa/Model/GeneralSettings.pm
+++ b/main/zarafa/src/EBox/Zarafa/Model/GeneralSettings.pm
@@ -123,7 +123,7 @@ __('Enable Active Sync (Microsoft Exchange syncronization protocol).'),
                                 editable      => 1,
                                 defaultValue  => 0,
                                 help =>
-__('Enable Single Sign On on the Webaccess and Webapp interface.'),
+                                  __('Enable only Single Sign-On on the Webaccess interface.'),
                                ),
        new EBox::Types::Select(
                                 fieldName     => 'vHost',

--- a/main/zarafa/stubs/apache.mas
+++ b/main/zarafa/stubs/apache.mas
@@ -95,27 +95,6 @@ Alias /Microsoft-Server-ActiveSync /usr/share/d-push/index.php
 </IfModule>
 % }
 
-% if ($enable_sso eq 'yes') {
-<IfModule mod_auth_kerb.c>
-<Directory /usr/share/zarafa-webaccess>
-  AuthType Kerberos
-  AuthName "Kerberos Login"
-  KrbMethodNegotiate On
-  KrbMethodK5Passwd On
-  KrbServiceName ZARAFA
-  KrbAuthRealms <% $realm %>
-  Krb5KeyTab /etc/zarafa/zarafa.keytab
-  require valid-user
-</Directory>
-<Directory /usr/share/zarafa-webapp>
-  AuthType Kerberos
-  AuthName "Kerberos Login"
-  KrbMethodNegotiate On
-  KrbMethodK5Passwd On
-  KrbServiceName ZARAFA
-  KrbAuthRealms <% $realm %>
-  Krb5KeyTab /etc/zarafa/zarafa.keytab
-  require valid-user
-</Directory>
-</IfModule>
+% if ($enable_sso) {
+<& /zarafa/zarafa-web-sso.mas, realm => $realm &>
 % }

--- a/main/zarafa/stubs/zarafa-web-sso.mas
+++ b/main/zarafa/stubs/zarafa-web-sso.mas
@@ -2,17 +2,7 @@
     $realm
 </%args>
 <IfModule mod_auth_kerb.c>
-<Directory /usr/share/zarafa-webaccess>
-  AuthType Kerberos
-  AuthName "Kerberos Login"
-  KrbMethodNegotiate On
-  KrbMethodK5Passwd Off
-  KrbServiceName HTTP
-  KrbAuthRealms <% $realm %>
-  Krb5KeyTab /etc/zarafa/zarafa.keytab
-  require valid-user
-</Directory>
-<Directory /usr/share/zarafa-webapp>
+<Directory /usr/share/zarafa-webaccess/>
   AuthType Kerberos
   AuthName "Kerberos Login"
   KrbMethodNegotiate On


### PR DESCRIPTION
- Disable Single Sign-On on webapp as it is not working and undocumented
- Make Single Sign-On work on webaccess using only a virtual host
