### PR TITLE
 Assure InnoDB is enabled in mysql 

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Assure InnoDB is enabled in mysql
 	+ Disable mode select when provisioned
 3.1.1
 	+ Implement additional openchange server deployment

--- a/main/openchange/src/EBox/OpenChange.pm
+++ b/main/openchange/src/EBox/OpenChange.pm
@@ -126,6 +126,7 @@ sub _setConf
     $self->_writeSOGoDefaultFile();
     $self->_writeSOGoConfFile();
     $self->_setupSOGoDatabase();
+    $self->_enableInnoDBIfNeeded();
 }
 
 sub _writeSOGoDefaultFile
@@ -207,6 +208,18 @@ sub _setupSOGoDatabase
     $db->sqlAsSuperuser(sql => "GRANT ALL ON $dbName.* TO $dbUser\@$dbHost " .
                                "IDENTIFIED BY \"$dbPass\";");
     $db->sqlAsSuperuser(sql => 'flush privileges;');
+}
+
+sub _enableInnoDBIfNeeded
+{
+    my ($self) = @_;
+
+    if (system ("mysql -e \"SHOW VARIABLES LIKE 'have_innodb'\" | grep -q DISABLED") == 0) {
+        EBox::Sudo::root(
+            "sed -i 's/innodb = off/innodb = on/' /etc/mysql/conf.d/zentyal.cnf",
+            "restart mysql"
+        );
+    }
 }
 
 # Method: menu


### PR DESCRIPTION
If InnoDB is not enabled mapi proxy dies in any operation which uses DB (most of them).

I have reused the same approach that the Zarafa module. It seem to work but it could be that in some situations is not good idea to restart mysql in save change process?
