### PR TITLE
Avoid aesthetical bug in loging through Zentyal Remote

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Avoid Apache error screen in login when entering through Zentyal
+	  Remote using password
 3.0.27
 	+ Fixed in-place boolean edit with non-basic types different to Union
 	+ Fixed side-effect in Model::Manager::_modelHasMultipleInstances() that

--- a/main/core/src/EBox/Auth.pm
+++ b/main/core/src/EBox/Auth.pm
@@ -250,7 +250,9 @@ sub loginCC
                 return HTTP_MOVED_TEMPORARILY;
             }
         }
-        return EBox::CGI::Run->run('/Login/Index', 'EBox');
+        EBox::initLogger('eboxlog.conf');
+        EBox::CGI::Run->run('/Login/Index', 'EBox');
+        return OK;
     }
 }
 


### PR DESCRIPTION
Avoid Apache error screen in login when entering through Zentyal
Remote using password
