### PR TITLE
 UTF8 decode DN when retrieving it from a LDAP object

### DIFF
--- a/main/users/ChangeLog
+++ b/main/users/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ UTF8 decode DN when retrieving it from a LDAP object
 3.3
 	+ Removed old migration code from 3.0 to 3.2
 	+ Set version to 3.3

--- a/main/users/src/EBox/Users/LdapObject.pm
+++ b/main/users/src/EBox/Users/LdapObject.pm
@@ -308,7 +308,9 @@ sub dn
 {
     my ($self) = @_;
 
-    return $self->_entry()->dn();
+    my $dn = $self->_entry()->dn();
+    utf8::decode($dn);
+    return $dn;
 }
 
 # Method: baseDn


### PR DESCRIPTION
This fixes http://trac.zentyal.org/ticket/7324 and probably more things. Observe that the get() method i nthe same object works the same way.
