### PR TITLE
Removing duplicated variable declaration

### DIFF
--- a/main/samba/src/EBox/Samba.pm
+++ b/main/samba/src/EBox/Samba.pm
@@ -255,7 +255,6 @@ sub _postServiceHook
         my $builtinAdministratorsSID = 'S-1-5-32-544';
         my $domainUsersSID = "$domainSID-513";
         my $domainGuestsSID = "$domainSID-514";
-        my $domainUsersSID = "$domainSID-513";
         my $systemSID = "S-1-5-18";
         my @superAdminSIDs = ($builtinAdministratorsSID, $domainAdminSID, $systemSID);
         my $readRights = SEC_FILE_EXECUTE | SEC_RIGHTS_FILE_READ;


### PR DESCRIPTION
Discovered while installing from command line with this warning:

"my" variable $domainUsersSID masks earlier declaration in same scope at /usr/share/perl5/EBox/Samba.pm line 258.
