### PR TITLE
Fix NT_STATUS_OBJECT_NAME_NOT_FOUND error

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Disable debug to parse ldbsearch command output when looking on idmap.ldb
+	+ Set case sensitive on a per share basis
 3.2.5
 	+ Fix netbios name no being updated when hostname change and samba module
 	  is not enabled

--- a/main/samba/src/EBox/LDB/IdMapDb.pm
+++ b/main/samba/src/EBox/LDB/IdMapDb.pm
@@ -61,7 +61,7 @@ sub getXidNumberBySID
     my ($self, $sid) = @_;
 
     EBox::debug("Searching for the XID of '$sid'");
-    my $output = EBox::Sudo::root("ldbsearch -H $self->{file} \"(&(objectClass=sidMap)(cn=$sid))\" | grep -v ^GENSEC");
+    my $output = EBox::Sudo::root("ldbsearch -H $self->{file} \"(&(objectClass=sidMap)(cn=$sid))\" -d0 | grep -v ^GENSEC");
     my $ldifBuffer = join ('', @{$output});
     EBox::debug($ldifBuffer);
 
@@ -94,7 +94,7 @@ sub consumeNextXidNumber
     my ($self) = @_;
 
     EBox::debug("Searching for the next XID Number to use");
-    my $output = EBox::Sudo::root("ldbsearch -H $self->{file} \"(distinguishedName=CN=CONFIG)\" | grep -v ^GENSEC");
+    my $output = EBox::Sudo::root("ldbsearch -H $self->{file} \"(distinguishedName=CN=CONFIG)\" -d0 | grep -v ^GENSEC");
     my $ldifBuffer = join ('', @{$output});
     EBox::debug($ldifBuffer);
 

--- a/main/samba/stubs/smb.conf.mas
+++ b/main/samba/stubs/smb.conf.mas
@@ -51,8 +51,6 @@ if (EBox::Config::boolean('join_vista_with_guest_shares')) {
 % }
     server signing = auto
 
-    case sensitive = no
-
     log level = 3
     log file = /var/log/samba/samba.log
 
@@ -77,16 +75,19 @@ if (EBox::Config::boolean('join_vista_with_guest_shares')) {
     path = <% $profilesPath %>
     browseable = no
     read only = no
+    case sensitive = yes
 %   }
 
 [netlogon]
     path = <% $sysvolPath %>/<% $domain %>/scripts
     browseable = no
     read only = yes
+    case sensitive = no
 
 [sysvol]
     path = <% $sysvolPath %>
     read only = no
+    case sensitive = no
 % }
 
 [homes]
@@ -94,6 +95,7 @@ if (EBox::Config::boolean('join_vista_with_guest_shares')) {
     path = /home/%S
     read only = no
     browseable = no
+    case sensitive = yes
     create mask = 0611
     directory mask = 0711
 % my $av = ($antivirus xor defined($antivirus_exceptions->{'users'}));
@@ -131,6 +133,7 @@ if (EBox::Config::boolean('join_vista_with_guest_shares')) {
     path = <% $share->{path} %>
     browseable = Yes
     read only = No
+    case sensitive = yes
     force create mode = 0660
     force directory mode = 0660
 % my $av = ($antivirus xor defined($antivirus_exceptions->{'share'}->{$share->{'share'}}));
@@ -169,6 +172,7 @@ if (EBox::Config::boolean('join_vista_with_guest_shares')) {
     comment = Point and Print Printer Drivers
     path = /opt/samba4/var/print
     read only = No
+    case sensitive = no
 
 [printers]
     comment = All Printers
@@ -176,6 +180,7 @@ if (EBox::Config::boolean('join_vista_with_guest_shares')) {
     browseable = Yes
     read only = No
     printable = Yes
+    case sensitive = no
 % }
 
 % if ($antivirus) {
@@ -184,4 +189,5 @@ if (EBox::Config::boolean('join_vista_with_guest_shares')) {
     path = <% $antivirus_config->{quarantine_dir} %>
     browseable = Yes
     read only = No
+    case sensitive = yes
 % }


### PR DESCRIPTION
If the share contain two folders with the samba name but different case, the
smb list command list both of them, but when opening a folder always the lower
cased one is opened, so trying to open a file fails with object name not found.
