### PR TITLE
Make sure that we always discard audit of changes when we...

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Make sure that we always commit/discard audit of changes when we
+	  save/revoke all modules
 	+ Fixed JS glitch which broke the dashboard periodical updates
 	+ Better check of referer which skips cloud domain if it does not exists
 	+ Avoid warning when stopping a module without FirewallHelper

--- a/main/core/src/EBox/GlobalImpl.pm
+++ b/main/core/src/EBox/GlobalImpl.pm
@@ -380,6 +380,12 @@ sub revokeAllModules
         };
     }
 
+    # discard logging of revoked changes
+    my $audit = $self->modInstance($ro, 'audit');
+    if ($audit) {
+        $audit->discard();
+    }
+
     if (not $failed) {
         $progress->setAsFinished() if $progress;
         return;
@@ -605,10 +611,16 @@ sub saveAllModules
         # in first install sysinfo module is in changed state
         push @mods, 'sysinfo';
     } else {
-        # not first ime, getting changed modules
+        # not first time, getting changed modules
         @mods = @{$self->modifiedModules('save')};
         $modNames = join (' ', @mods);
         EBox::info("Saving config and restarting services: @mods");
+    }
+
+    # commit log of saved changes
+    my $audit = EBox::GlobalImpl->modInstance($ro, 'audit');
+    if ($audit) {
+        $audit->commit();
     }
 
     # run presave hooks

--- a/main/core/src/scripts/global-action
+++ b/main/core/src/scripts/global-action
@@ -33,14 +33,10 @@ if ($progressId) {
 
 try {
     my $global = EBox::Global->getInstance();
-    my $audit = $global->modInstance('audit');
-
     if ($action eq 'saveAllModules') {
         $global->saveAllModules(@callParams);
-        $audit->commit();
     } elsif ($action eq 'revokeAllModules') {
         $global->revokeAllModules(@callParams);
-        $audit->discard();
     }
 } otherwise {
     my $ex = shift @_;


### PR DESCRIPTION
... revoke them

This is a more rational place where commit/discard logaudit so we are more sure of avoiding to forget to do it.
