### PR TITLE
Decode givenName, sn and description before propagating it from OpenLDAP...

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,7 @@
 HEAD
+	+ Decode givenName, sn and description before propagating it from OpenLDAP
+	  to Samba so it doesn't fail due to encoding issues
+	  (https://projects.zentyal.com/issues/6582).
 	+ Don't put duplicate bridge interfaces in smb.conf
 	+ Don't allow a share with file system root as path
 	+ Explicitly set firewall version dependency in control file

--- a/main/samba/src/EBox/SambaLdapUser.pm
+++ b/main/samba/src/EBox/SambaLdapUser.pm
@@ -186,6 +186,10 @@ sub _modifyUser
         my $gn = $zentyalUser->get('givenName');
         my $sn = $zentyalUser->get('sn');
         my $desc = $zentyalUser->get('description');
+        # Workaround for https://projects.zentyal.com/issues/6582
+        utf8::encode($gn);
+        utf8::encode($sn);
+        utf8::encode($desc);
         $sambaUser->set('givenName', $gn, 1);
         $sambaUser->set('sn', $sn, 1);
         $sambaUser->set('description', $desc, 1);
@@ -330,7 +334,10 @@ sub _modifyGroup
             push (@{$sambaMembersDNs}, $sambaUser->dn());
         }
         $sambaGroup->set('member', $sambaMembersDNs, 1);
-        $sambaGroup->set('description', scalar ($zentyalGroup->get('description')), 1);
+        my $description = scalar ($zentyalGroup->get('description'));
+        # Workaround for https://projects.zentyal.com/issues/6582
+        utf8::encode($description);
+        $sambaGroup->set('description', $description, 1);
         $sambaGroup->save();
     } otherwise {
         my ($error) = @_;


### PR DESCRIPTION
... to Samba

Running test suite: Shares and Antivirus Samba tests

Running test: InstallNonProfilePackages in host zentyal-server
Executing MODULES="samba" SCRIPT="-3.0" /tmp/SFcuNfzXIe/InstallNonProfilePackages  > /var/www/anste/samba/shares-antivirus/InstallNonProfilePackages.txt
Result: 0

Running test: EnableModules in host zentyal-server
Running test: MODULES="network firewall dns ntp users samba logs" BASE_URL="https://10.6.7.10" /tmp/HBGXQso2JD/EnableModules  > /var/www/anste/samba/shares-antivirus/EnableModules.txt 2>&1
Result: 0

Running test: ConfigNetworkSetExternal in host zentyal-server
Running test: BASE_URL="https://10.6.7.10" IFACE="eth2" /tmp/rQOD_PnOk0/ConfigNetworkSetExternal  > /var/www/anste/samba/shares-antivirus/ConfigNetworkSetExternal.txt 2>&1
Result: 0

Running test: ChangeDefaultQuota in host zentyal-server
Running test: QUOTA="1" BASE_URL="https://10.6.7.10" /tmp/KGesE2dnFv/ChangeDefaultQuota  > /var/www/anste/samba/shares-antivirus/ChangeDefaultQuota.txt 2>&1
Result: 0

Running test: AddUserWithNonASCIIChars in host zentyal-server
Wide character in print at /usr/share/perl5/ANSTE/Test/Runner.pm line 518.
Wide character in print at /usr/share/perl5/ANSTE/System/System.pm line 113.
Running test: PASSWORD="foo" NAME="Bláh" SURNAME="Foçó" USERNAME="non-ascii-user" BASE_URL="https://10.6.7.10" COMMENT="I have non ASCII chars in my pants! áéíóúñç€" /tmp/Qq_p3mMduS/AddUserWithNonASCIIChars  > /var/www/anste/samba/shares-antivirus/AddUserWithNonASCIIChars.txt 2>&1
Result: 0

Running test: EditUserWithNonASCIIChars in host zentyal-server
Running test: NAME="Bl�h2" USERNAME="non-ascii-user" BASE_URL="https://10.6.7.10" /tmp/kA4PS8Mj7T/EditUserWithNonASCIIChars  > /var/www/anste/samba/shares-antivirus/EditUserWithNonASCIIChars.txt 2>&1
Result: 0

Running test: AddUserFoo in host zentyal-server
Running test: PASSWORD="foo" USERNAME="foo" BASE_URL="https://10.6.7.10" /tmp/2ytmL1ypxB/AddUserFoo  > /var/www/anste/samba/shares-antivirus/AddUserFoo.txt 2>&1
Result: 0

The other tests failed due to errors unrelated with my changes...

This branch fixes the EditUserWithNonASCIIChars test so it doesn't add an error to the zentyal log (the test pass always without the fix but leaving a "present" on the log).
