### PR TITLE
Fixed the way we propagate optional fields, removing it when empty

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fixed the way we propagate optional fields, removing it when empty
 	+ Decode givenName, sn and description before propagating it from OpenLDAP
 	  to Samba so it doesn't fail due to encoding issues
 	+ Don't put duplicate bridge interfaces in smb.conf

--- a/main/samba/src/EBox/SambaLdapUser.pm
+++ b/main/samba/src/EBox/SambaLdapUser.pm
@@ -189,10 +189,16 @@ sub _modifyUser
         # Workaround for accented users problem
         utf8::encode($gn);
         utf8::encode($sn);
-        utf8::encode($desc);
         $sambaUser->set('givenName', $gn, 1);
         $sambaUser->set('sn', $sn, 1);
-        $sambaUser->set('description', $desc, 1);
+
+        if ($desc) {
+            utf8::encode($desc);
+            $sambaUser->set('description', $desc, 1);
+        } else {
+            $sambaUser->delete('description', 1);
+        }
+
         if (defined($zentyalPwd)) {
             $sambaUser->changePassword($zentyalPwd, 1);
         } else {
@@ -335,9 +341,13 @@ sub _modifyGroup
         }
         $sambaGroup->set('member', $sambaMembersDNs, 1);
         my $description = scalar ($zentyalGroup->get('description'));
-        # Workaround for accented users problem
-        utf8::encode($description);
-        $sambaGroup->set('description', $description, 1);
+        if ($description) {
+            # Workaround for accented users problem
+            utf8::encode($description);
+            $sambaGroup->set('description', $description, 1);
+        } else {
+            $sambaGroup->delete('description', 1);
+        }
         $sambaGroup->save();
     } otherwise {
         my ($error) = @_;


### PR DESCRIPTION
This fix is required to reduce the noise on the log errors (it's a side effect of my previous change, however the bug was already there before my changes is just that it's now detected by tests).

This fix is a backport from 3.2
