### PR TITLE
Pass HTTP_PROXY sys env var

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Pass HTTP_PROXY system environment variable to CGIs as they are
+	  used in Zentyal modules
 3.0.29
 	+ Make sure that we always discard audit of changes when we revoke them
 	+ Include contents of /etc/resolv.conf in bug report

--- a/main/core/stubs/apache.mas
+++ b/main/core/stubs/apache.mas
@@ -39,6 +39,7 @@ KeepAlive Off
 MaxKeepAliveRequests 500
 KeepAliveTimeout 15
 AddDefaultCharset utf-8
+PassEnv HTTP_PROXY
 
 PidFile <% $tmpdir %>/apache.pid
 


### PR DESCRIPTION
- Pass HTTP_PROXY system environment variable to CGIs as they are
  used in Zentyal modules

This has been tested in 3.2 as well. A reboot is required to make HTTP proxy var available in all the systems though.
