### PR TITLE
delete migration code from previous versions

### DIFF
--- a/main/antivirus/ChangeLog
+++ b/main/antivirus/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Set version to 3.3
 3.2
 	+ Set version to 3.2

--- a/main/antivirus/src/EBox/AntiVirus.pm
+++ b/main/antivirus/src/EBox/AntiVirus.pm
@@ -412,23 +412,4 @@ sub tableInfo
     }];
 }
 
-# Method: initialSetup
-#
-# Overrides:
-#
-#   EBox::Module::Base::initialSetup
-#
-sub initialSetup
-{
-    my ($self, $version) = @_;
-
-    # Execute initial-setup script
-    $self->SUPER::initialSetup($version);
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
-}
-
 1;

--- a/main/dhcp/ChangeLog
+++ b/main/dhcp/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Fixed regression which broke DHCP next-server options being written
 	  to config (Contributed by on-jz)
 	+ Set version to 3.3

--- a/main/dhcp/src/EBox/DHCP.pm
+++ b/main/dhcp/src/EBox/DHCP.pm
@@ -160,11 +160,6 @@ sub initialSetup
         push (@cmds, 'chmod 0750 ' . KEYS_DIR);
         EBox::Sudo::root(@cmds);
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 # Method: appArmorProfiles

--- a/main/dns/ChangeLog
+++ b/main/dns/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Fix set of dynamic attribute in domain table when samba module is enabled
 	  again
 	+ Do not write reverse zone files if generate_reverse_zones is false

--- a/main/dns/src/EBox/DNS.pm
+++ b/main/dns/src/EBox/DNS.pm
@@ -571,17 +571,6 @@ sub initialSetup
         $firewall->saveConfigRecursive();
     }
 
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
-
-    # Upgrade from 3.2.1 to 3.2.2
-    if (defined $version and EBox::Util::Version::compare($version, '3.2.2') < 0) {
-        EBox::Sudo::root('rm -f /etc/init/ebox.bind9.conf');
-        EBox::Sudo::root('rm -f /etc/init/ebox.bind9.override');
-    }
-
     # Execute initial-setup script to create SQL tables
     $self->SUPER::initialSetup($version);
 }

--- a/main/ftp/ChangeLog
+++ b/main/ftp/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Force depend on PPA version of vsftpd with the chroot patch
 	+ Added Support for chrooting users
 	+ Set version to 3.3

--- a/main/ftp/src/EBox/FTP.pm
+++ b/main/ftp/src/EBox/FTP.pm
@@ -84,11 +84,6 @@ sub initialSetup
 
         $firewall->saveConfigRecursive();
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 sub _services

--- a/main/ipsec/ChangeLog
+++ b/main/ipsec/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Set version to 3.3
 3.2
 	+ Set version to 3.2

--- a/main/ipsec/src/EBox/IPsec.pm
+++ b/main/ipsec/src/EBox/IPsec.pm
@@ -155,11 +155,6 @@ sub initialSetup
 
         $firewall->saveConfigRecursive();
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 sub _services

--- a/main/jabber/ChangeLog
+++ b/main/jabber/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Set version to 3.3
 3.2
 	+ Set version to 3.2

--- a/main/jabber/src/EBox/Jabber.pm
+++ b/main/jabber/src/EBox/Jabber.pm
@@ -108,11 +108,6 @@ sub initialSetup
 
         $firewall->saveConfigRecursive();
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 sub _services

--- a/main/mail/ChangeLog
+++ b/main/mail/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Preservice and postservice hooks now should work properly
 	+ Fixed regression which broke external account modification
 	+ Set version to 3.3

--- a/main/mail/src/EBox/Mail.pm
+++ b/main/mail/src/EBox/Mail.pm
@@ -224,11 +224,6 @@ sub initialSetup
         # changes, so this default could be set to the hostname
         $self->set_string(BOUNCE_ADDRESS_KEY, BOUNCE_ADDRESS_DEFAULT);
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 sub _serviceRules

--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Write resolvconf head, base and tail
 	+ Set proper file name for HTTP proxy configuration for APT
 	+ Set HTTP proxy wide settings in /etc/environment

--- a/main/network/src/EBox/Network.pm
+++ b/main/network/src/EBox/Network.pm
@@ -253,35 +253,6 @@ sub initialSetup
             EBox::warn('Network configuration import failed');
         };
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
-
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.2.2') < 0)) {
-        my $resolverModel = $self->model('DNSResolver');
-        foreach my $id (@{$resolverModel->ids()}) {
-            my $row = $resolverModel->row($id);
-            my $interfaceElement = $row->elementByName('interface');
-            my $interfaceValue = $interfaceElement->value();
-            unless (defined $interfaceValue and length $interfaceValue) {
-                $interfaceElement->setValue("zentyal.$id");
-                $row->store();
-            }
-        }
-        my $searchDomainModel = $self->model('SearchDomain');
-        my $domainRow = $searchDomainModel->row();
-        my $ifaceElement = $domainRow->elementByName('interface');
-        $ifaceElement->setValue('zentyal.' . $domainRow->id());
-        $domainRow->store();
-    }
-
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.2.3') < 0)) {
-        my @cmds = ('rm -f /etc/profile.d/zentyal-proxy.sh',
-                    'rm -f /etc/apt/apt.conf.d/99proxy.conf');
-        EBox::Sudo::silentRoot(@cmds);
-    }
 }
 
 # Method: enableActions

--- a/main/ntp/ChangeLog
+++ b/main/ntp/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Set version to 3.3
 3.2
 	+ Set version to 3.2

--- a/main/ntp/src/EBox/NTP.pm
+++ b/main/ntp/src/EBox/NTP.pm
@@ -146,11 +146,6 @@ sub initialSetup
         }
         $fw->saveConfigRecursive();
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 sub _syncDate

--- a/main/nut/ChangeLog
+++ b/main/nut/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Set version to 3.3
 3.2
 	+ Set version to 3.2

--- a/main/nut/src/EBox/NUT.pm
+++ b/main/nut/src/EBox/NUT.pm
@@ -167,20 +167,4 @@ sub _daemons
     ];
 }
 
-# Method: initialSetup
-#
-# Overrides:
-#
-#   EBox::Module::Base::initialSetup
-#
-sub initialSetup
-{
-    my ($self, $version) = @_;
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
-}
-
 1;

--- a/main/printers/ChangeLog
+++ b/main/printers/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Set version to 3.3
 3.2
 	+ Set version to 3.2

--- a/main/printers/src/EBox/Printers.pm
+++ b/main/printers/src/EBox/Printers.pm
@@ -112,11 +112,6 @@ sub initialSetup
                            );
         $firewall->saveConfigRecursive();
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 # Method: enableActions

--- a/main/radius/ChangeLog
+++ b/main/radius/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Log helper changes: only check no-via lines, this avoid
 	  duplicate lines but made us lose the 'TLS tunnel' MAC and 'user
 	  not found' event. Also best treatment of MAC addresses, thanks

--- a/main/radius/src/EBox/Radius.pm
+++ b/main/radius/src/EBox/Radius.pm
@@ -149,11 +149,6 @@ sub initialSetup
 
         $firewall->saveConfigRecursive();
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 sub _services

--- a/main/squid/ChangeLog
+++ b/main/squid/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Transparent proxy redirection for openvpn servers' clients
 	+ Moved EBox::SquidFirewall to EBox::Squid::Firewall
 	+ Avoid error in access rules model when using external AD and

--- a/main/squid/src/EBox/Squid.pm
+++ b/main/squid/src/EBox/Squid.pm
@@ -132,11 +132,6 @@ sub initialSetup
         $self->model('AccessRules')->add(source => { any => undef },
                                          policy => { allow => undef });
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 # Method: enableActions

--- a/main/webserver/ChangeLog
+++ b/main/webserver/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Delete migration code from old versions
 	+ Set version to 3.3
 3.2
 	+ Set version to 3.2

--- a/main/webserver/src/EBox/WebServer.pm
+++ b/main/webserver/src/EBox/WebServer.pm
@@ -173,11 +173,6 @@ sub initialSetup
         $settings->setValue(port      => $port);
         $settings->setValue(enableDir => EBox::WebServer::Model::GeneralSettings::DefaultEnableDir());
     }
-
-    # Upgrade from 3.0
-    if (defined ($version) and (EBox::Util::Version::compare($version, '3.1') < 0)) {
-        $self->_overrideDaemons() if $self->configured();
-    }
 }
 
 # Method: depends


### PR DESCRIPTION
As upgrading to 3.3 should be done only from the last 3.2.X packages
and migration code for that will be added if needed before the 3.3 release
