### PR TITLE
Fixed version required in samba dependency

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fixed version required in samba dependency
 	+ Use ou=Users as baseDN in sogo.conf if openchange_disable_multiou=yes
 	+ Changed field names to use the same terminology on Exchange
 	  installations

--- a/main/openchange/debian/precise/control
+++ b/main/openchange/debian/precise/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.2
 Package: zentyal-openchange
 Architecture: all
 Depends: zentyal-core (>= 3.3~1), zentyal-core (<< 3.4),
- zentyal-mail, zentyal-samba,
+ zentyal-mail, zentyal-samba (>=3.3~1),
  openchangeserver (>= 1:2.0-QUADRANT-66-g403062e-zentyal2),
  libstring-random-perl,
  sogo-openchange (>= 2.1.0-zentyal6),


### PR DESCRIPTION
Otherwise after a dist-upgrade you can have the old zentyal-samba version without openchange support
