### PR TITLE
Fixed RAID.pm to handle mdstat extra output text "(read-only)"

### DIFF
--- a/main/core/src/EBox/Report/RAID.pm
+++ b/main/core/src/EBox/Report/RAID.pm
@@ -339,6 +339,9 @@ sub _processDeviceMainLine
     my ($line) = @_;
     my %deviceInfo;
 
+    # Remove extra state info like "(read-only)" and "(auto-read-only)"
+    $line =~ s/\(\S*\)//;
+    
     my ($activeTag, $raidType, @raidDevicesTags) = split '\s', $line;
 
     $deviceInfo{active}= ($activeTag eq 'active') ? 1 : 0;


### PR DESCRIPTION
This fixes the case where mdstat includes some extra information
in the output text which breaks the Zentyal RAID monitoring code.
Closes Issue #748
