### PR TITLE
 Disable seccomp sandboxing in the conf of vsftpd to avoid errors

### DIFF
--- a/main/ftp/ChangeLog
+++ b/main/ftp/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Disable seccomp sandboxing in the conf to avoid errors
 	+ Delete migration code from old versions
 	+ Force depend on PPA version of vsftpd with the chroot patch
 	+ Added Support for chrooting users

--- a/main/ftp/stubs/vsftpd.conf.mas
+++ b/main/ftp/stubs/vsftpd.conf.mas
@@ -122,3 +122,7 @@ force_local_data_ssl=<% ($ssl eq 'forcessl') ? 'YES' : 'NO' %>
 % } else {
 ssl_enable=NO
 % }
+#
+# Disable seccomp sandboxing new feature because it causes errors
+# https://bugs.launchpad.net/ubuntu/+source/vsftpd/+bug/1195816
+seccomp_sandbox=NO


### PR DESCRIPTION
This fix the ANSTE tests and allow to write without giving the annoying problem of 500 OOPS: priv_sock_get_cmd

https://bugs.launchpad.net/ubuntu/+source/vsftpd/+bug/1195816

http://technologytales.com/2013/09/21/turning-off-seccomp-sandbox-in-vsftpd/
