### PR TITLE
Added precondition check to block IPsec configuration without defining a...

### DIFF
--- a/main/ipsec/ChangeLog
+++ b/main/ipsec/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Added precondition check for existing 'external' interface.
 	+ Added missing EBox::Exceptions uses
 3.2
 	+ Set version to 3.2

--- a/main/ipsec/src/EBox/IPsec/Model/Connections.pm
+++ b/main/ipsec/src/EBox/IPsec/Model/Connections.pm
@@ -283,4 +283,31 @@ sub acquireVPNConfigurationModel
     }
 }
 
+# Method: precondition
+#
+#   Overrid <EBox::Model::DataTable::precondition>
+#
+#   Num of external interfaces > 0
+sub precondition
+{
+    my ($self) = @_;
+    my $network = $self->global()->modInstance('network');
+    return (scalar(@{$network->ExternalIfaces()}) > 0);
+}
+
+# Method: preconditionFailMsg
+#
+#   Overrid <EBox::Model::DataTable::preconditionFailMsg>
+#
+sub preconditionFailMsg
+{
+
+    return __x("IPsec can only be configured on interfaces tagged as 'external'"
+                   . ' Check your interface '
+                   . 'configuration to match, at '
+                   . '{openhref}Network->Interfaces{closehref}',
+               openhref  => '<a href="/Network/Ifaces">',
+               closehref => '</a>');
+}
+
 1;


### PR DESCRIPTION
...n external interface first

This fix includes a new really basic suite for IPsec.

```
IPSec Test Suite
    InstallNonProfilePackages: OK
    EnableModules: OK
    TestIPSecPreconditionPresent: OK
    ConfigNetworkSetExternal: OK
    TestIPSecAddConnectionButtonPresent: OK
    check-zentyal-log: OK
    check-syslog-apparmor: OK
```
