### PR TITLE
Fixed RAID.pm to handle mdstat extra output text "(*read-only)"

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Fixed mdstat output processing to remove "(auto-read-only)"
 3.0.30
 	+ Pass HTTP_PROXY system environment variable to CGIs as they are
 	  used in Zentyal modules

--- a/main/core/src/EBox/Report/RAID.pm
+++ b/main/core/src/EBox/Report/RAID.pm
@@ -339,6 +339,9 @@ sub _processDeviceMainLine
     my ($line) = @_;
     my %deviceInfo;
 
+    # Remove extra state info like "(read-only)" and "(auto-read-only)"
+    $line =~ s/\s+\(\S*read-only\)//;
+
     my ($activeTag, $raidType, @raidDevicesTags) = split '\s', $line;
 
     $deviceInfo{active}= ($activeTag eq 'active') ? 1 : 0;


### PR DESCRIPTION
This fixes the case where mdstat includes some extra information
in the output text which breaks the Zentyal RAID monitoring code.
Closes Issue #748
