### PR TITLE
Show new organization selector by default and block Provision submit wit...

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,4 +1,6 @@
-HEAD
+3.3
+	+ Show new organization selector by default and block Provision submit
+	  with empty Organization Names
 	+ Added sieve features
 	+ Added autodiscovery of server parameters
 	+ Removed the deprovision option, it needs more work to be useful
@@ -14,7 +16,6 @@ HEAD
 	  installations
 	+ Added the firstorg and firstou arguments also when provisioning the
 	  openchangedb and newuser part
-3.3
 	+ Switch from Error to TryCatch for exception handling
 	+ Use new enableInnoDbIfNeeded() from core
 	+ Mailbox migration user interface

--- a/main/openchange/src/EBox/OpenChange/Model/Provision.pm
+++ b/main/openchange/src/EBox/OpenChange/Model/Provision.pm
@@ -73,15 +73,15 @@ sub _table
             printableName => __('Organization Name'),
             editable      => 1,
             subtypes      => [
-                new EBox::Types::Select(
-                    fieldName     => 'existingorganizationname',
-                    printableName => __('Existing One'),
-                    populate      => \&_existingOrganizationNames,
-                    editable      => 1),
                 new EBox::Types::Text(
                     fieldName     => 'neworganizationname',
                     printableName => __('New One'),
                     defaultValue  => $self->_defaultOrganizationName(),
+                    editable      => 1),
+                new EBox::Types::Select(
+                    fieldName     => 'existingorganizationname',
+                    printableName => __('Existing One'),
+                    populate      => \&_existingOrganizationNames,
                     editable      => 1),
             ])
         );
@@ -340,6 +340,10 @@ sub _doProvision
     my $enableUsers = $params{enableUsers};
 #    my $registerAsMain = $params{registerAsMain};
     my $additionalInstallation = 0;
+
+    unless ($organizationName) {
+        throw EBox::Exceptions::DataMissing(data => __('Organization Name'));
+    }
 
     foreach my $organization (@{$self->{organizations}}) {
         if ($organization->name() eq $organizationName) {


### PR DESCRIPTION
...h empty Organization Names

The error if the submited field is empty doesn't appear in the UI due to a bug in the infrastructure... Josh is going to investigate it because I found the same behavior in other forms.
