### PR TITLE
Allow to use vdomains table when module is unconfigured

### DIFF
--- a/main/mail/ChangeLog
+++ b/main/mail/ChangeLog
@@ -1,4 +1,5 @@
 3.3
+	+ Allow to use vdomains table when module is unconfigured
 	+ Dovecot passdb reordering and typo
 	+ Switch from Error to TryCatch for exception handling
 	+ Added required code to integrate with OpenChange

--- a/main/mail/src/EBox/Mail/Model/VDomainAliases.pm
+++ b/main/mail/src/EBox/Mail/Model/VDomainAliases.pm
@@ -110,33 +110,6 @@ sub validateTypedRow
     }
 }
 
-# Method: precondition
-#
-#       Check if the module is configured
-#
-# Overrides:
-#
-#       <EBox::Model::DataTable::precondition>
-sub precondition
-{
-    my ($self)= @_;
-    my $mail = $self->global()->modInstance('mail');
-    return $mail->configured();
-}
-
-# Method: preconditionFailMsg
-#
-#       Check if the module is configured
-#
-# Overrides:
-#
-#       <EBox::Model::DataTable::precondition>
-sub preconditionFailMsg
-{
-        return __('You must enable the mail module in module ' .
-                  'status section in order to use it.');
-}
-
 sub deletedRowNotify
 {
     my ($self, $row, $force) = @_;

--- a/main/mail/src/EBox/Mail/Model/VDomains.pm
+++ b/main/mail/src/EBox/Mail/Model/VDomains.pm
@@ -92,34 +92,6 @@ sub _table
     return $dataTable;
 }
 
-# Method: precondition
-#
-#       Check if the module is configured
-#
-# Overrides:
-#
-#       <EBox::Model::DataTable::precondition>
-sub precondition
-{
-    my $mail = EBox::Global->modInstance('mail');
-    return $mail->configured();
-}
-
-# Method: preconditionFailMsg
-#
-#       Check if the module is configured
-#
-# Overrides:
-#
-#       <EBox::Model::DataTable::precondition>
-sub preconditionFailMsg
-{
-    return __x('You must enable the mail module in {oh}Module ' .
-               'Status{ch} section in order to use it.',
-               oh => '<a href="/ServiceModule/StatusView">',
-               ch => '</a>');
-}
-
 sub alwaysBccByVDomain
 {
     my ($self) = @_;


### PR DESCRIPTION
- It seems that this preconditions are not longer needed because mail regenerate only the vdomains when it is configured..
