### PR TITLE
Update RemoteSettings.pm to allow rsync without a password

### DIFF
--- a/main/ebackup/src/EBox/Model/RemoteSettings.pm
+++ b/main/ebackup/src/EBox/Model/RemoteSettings.pm
@@ -926,6 +926,12 @@ sub configurationIsComplete
     if (not $user) {
         return 0;
     }
+
+    if ($method eq 'rsync') {
+        # rsync does not need password
+        return 1;
+    }
+
     my $password = $row->valueByName('password');
     if (not $password) {
         return 0;


### PR DESCRIPTION
The commit 205a4d0d0694c9513520177db4e3b1cfbbbed488 for #797 has broken my rsync backup configuration which has been working for a year or more on Zentyal 3.0.

Debugging this I tried running the backup manually:

<pre>
/usr/share/zentyal-ebackup/backup-tool --full
Backup module configuration is not completed. Configure it and retry
</pre>


I suggest updating the configurationIsComplete() function to not fail when there is no password defined for the rsync method.
