### PR TITLE
Fix warning on last inside an eval on automatic-conf-backup script

### DIFF
--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Fix warning on last inside an eval on automatic-conf-backup script
 3.0.28
 	+ Update support information due to offer 2013
 	+ Update messages in info models

--- a/main/remoteservices/src/scripts/automatic-conf-backup
+++ b/main/remoteservices/src/scripts/automatic-conf-backup
@@ -40,18 +40,20 @@ sub makeConfBackup
     my $backupService = new EBox::RemoteServices::Backup();
     my $automatic     = 1;
     my $backupName    = 'automatic-backup-' . time();
+    my $success       = 0;
     foreach my $attempt (1 .. ATTEMPT_NUM) {
         EBox::debug("Attempt $attempt to make the backup");
         try {
             $backupService->makeRemoteBackup($backupName,
                                              __('Automatic backup'),
                                              $automatic);
-            last;
+            $success = 1;
         } catch EBox::Exceptions::InvalidData with {
             my ($exc) = @_;
             EBox::debug("Backup corrupted in some way...");
             $exc->throw() if ($attempt == ATTEMPT_NUM);
         };
+        last if ($success);
     }
 }
 


### PR DESCRIPTION
This should be forward ported to 3.2 onwards.

Try::Catch::Lite has the same problem. Three automatic backups are done in a row ...

Pretty important :/
