### PR TITLE
 Select text clearer for interfaces which have virtual interfaces

### DIFF
--- a/main/firewall/ChangeLog
+++ b/main/firewall/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Select text clearer for interfaces which have virtual interfaces
 3.3
 	+ Switch from Error to TryCatch for exception handling
 	+ Added missing EBox::Exceptions uses

--- a/main/firewall/src/EBox/Firewall/Model/RedirectsTable.pm
+++ b/main/firewall/src/EBox/Firewall/Model/RedirectsTable.pm
@@ -224,6 +224,7 @@ sub _fieldDescription
              'fieldName' => 'interface',
              'printableName' => __('Interface'),
              'populate' => $self->interfacePopulateSub,
+             'disableCache' => 1,
              'editable' => 1);
     push (@tableHead, $iface);
 

--- a/main/firewall/src/EBox/Firewall/Model/RulesWithInterface.pm
+++ b/main/firewall/src/EBox/Firewall/Model/RulesWithInterface.pm
@@ -20,6 +20,8 @@ use warnings;
 
 package EBox::Firewall::Model::RulesWithInterface;
 
+use EBox::Gettext;
+
 sub interfacePopulateSub
 {
     my ($self) = @_;
@@ -39,11 +41,16 @@ sub interfacePopulateSub
             my $printableValue =  $net->ifaceAlias($iface);
             my @vifacesNames = @{ $net->vifaceNames($iface) };
             if (@vifacesNames) {
-                $printableValue = join ', ', ($printableValue, @vifacesNames);
+                EBox::debug("vifaces @vifacesNames");
+                EBox::debug(join(', ', @vifacesNames));
+                $printableValue = __x('{iface} (including {vifaces})',
+                                      iface => $printableValue,
+                                      vifaces => join(', ', @vifacesNames)
+                                     );
             }
 
-            push(@options, { 'value' => $iface,
-                             'printableValue' => $printableValue  });
+            push @options, { 'value' => $iface,
+                             'printableValue' => $printableValue  };
         }
 
         return \@options;

--- a/main/firewall/src/EBox/Firewall/Model/SNAT.pm
+++ b/main/firewall/src/EBox/Firewall/Model/SNAT.pm
@@ -63,6 +63,7 @@ sub _fieldDescription
              'fieldName' => 'interface',
              'printableName' => __('Outgoing interface'),
              'populate' => $self->interfacePopulateSub,
+             'disableCache' => 1,
              'editable' => 1);
     push (@tableHead, $iface);
 


### PR DESCRIPTION
The text have been changed to 'eth1 (including eth1:8, eth1:6, eth1:1, eth1:78)' . Before it was 'eth1,  eth1:8, eth1:6, eth1:1, eth1:78; . This change aims to make clearer that the vifaces are included in the 'normal' iface
