### PR TITLE
Update install button when clicking select all checkbox

### DIFF
--- a/main/software/ChangeLog
+++ b/main/software/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Update install button when clicking select all checkbox
 	+ Send an alert if a restart is required after performing an automatic
 	  update with auto-updater
 3.3

--- a/main/software/src/templates/ebox.mas
+++ b/main/software/src/templates/ebox.mas
@@ -592,7 +592,7 @@ $buttonId
       <% __('Select') %>
       <div>
       <input type='checkbox'
-             onchange='Zentyal.SoftwareManagementUI.checkAll("<% $id %>", $(this).prop("checked"));'
+             onchange='Zentyal.SoftwareManagementUI.checkAll("<% $id %>", $(this).prop("checked"), "<% $buttonId %> ");'
        />
       </div>
     </th>

--- a/main/software/www/js/software-management.js
+++ b/main/software/www/js/software-management.js
@@ -131,8 +131,9 @@ Zentyal.SoftwareManagementUI.updateTicks = function() {
     }
 };
 
-Zentyal.SoftwareManagementUI.checkAll = function(table, value) {
+Zentyal.SoftwareManagementUI.checkAll = function(table, value, buttonId) {
     $('#' + table  + ' :checkbox').prop('checked', value);
+    Zentyal.SoftwareManagementUI.updateActionButton(table, buttonId);
 };
 
 Zentyal.SoftwareManagementUI.sendForm = function(action, container, popup, title) {


### PR DESCRIPTION
On _Zentyal Components_ section the _install_ button was not being updated after clicking the select all checkbox. This affects only 3.3
