### PR TITLE
Fix EBox::Types::Composite::cmp

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Fix EBox::Types::Composite::cmp to store changes when only last type
+	  is modified
 3.0.32
 	+ Display remote services messages if they exist on Dashboard
 	+ Fixed mdstat output processing to remove "(auto-read-only)"

--- a/main/core/src/EBox/Types/Composite.pm
+++ b/main/core/src/EBox/Types/Composite.pm
@@ -174,7 +174,7 @@ sub cmp
 
     return undef unless ( scalar(@selfTypes) == scalar(@comparedTypes) );
     my $returnValue = undef;
-    for( my $idx = 0; $idx < $#selfTypes; $idx++) {
+    for( my $idx = 0; $idx <= $#selfTypes; $idx++) {
         my $singleCmp = $selfTypes[$idx]->cmp($comparedTypes[$idx]);
         if ( not defined($returnValue) ) {
             $returnValue = $singleCmp;


### PR DESCRIPTION
To store changes when only last type is modified

The severity of this bug is important.
