### PR TITLE
Use sharedscripts in zentyal-core logrotate conf file

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Use sharedscripts in zentyal-core logrotate to avoid triggering
+	  in every log file
 	+ Fix EBox::Types::Composite::cmp to store changes when only last type
 	  is modified
 3.0.32

--- a/main/core/debian/precise/zentyal-core.logrotate
+++ b/main/core/debian/precise/zentyal-core.logrotate
@@ -7,6 +7,7 @@
         missingok
         delaycompress
         notifempty
+        sharedscripts
         postrotate
                 /usr/share/zentyal/restart-trigger
         endscript


### PR DESCRIPTION
To avoid triggering in every log file (1 time vs. 6 times).

See example of logrotate -v /etc/logrotate.d/zentyal-core:

```
reading config file /etc/logrotate.d/zentyal-core
reading config info for /var/log/zentyal/error.log /var/log/zentyal/access.log /var/log/zentyal/zentyal.log /var/log/zentyal/redis-server.log /var/log/zentyal/events.log /var/log/zentyal/events.err


Handling 1 logs

rotating pattern: /var/log/zentyal/error.log /var/log/zentyal/access.log /var/log/zentyal/zentyal.log /var/log/zentyal/redis-server.log /var/log/zentyal/events.log /var/log/zentyal/events.err
 10485760 bytes (7 rotations)
empty log files are not rotated, old logs are removed
considering log /var/log/zentyal/error.log
  log does not need rotating
considering log /var/log/zentyal/access.log
  log does not need rotating
considering log /var/log/zentyal/zentyal.log
  log needs rotating
considering log /var/log/zentyal/redis-server.log
  log does not need rotating
considering log /var/log/zentyal/events.log
  log does not need rotating
considering log /var/log/zentyal/events.err
  log does not need rotating
rotating log /var/log/zentyal/zentyal.log, log->rotateCount is 7
dateext suffix '-20140117'
glob pattern '-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
compressing log with: /bin/gzip
renaming /var/log/zentyal/zentyal.log.7.gz to /var/log/zentyal/zentyal.log.8.gz (rotatecount 7, logstart 1, i 7),
renaming /var/log/zentyal/zentyal.log.6.gz to /var/log/zentyal/zentyal.log.7.gz (rotatecount 7, logstart 1, i 6),
renaming /var/log/zentyal/zentyal.log.5.gz to /var/log/zentyal/zentyal.log.6.gz (rotatecount 7, logstart 1, i 5),
renaming /var/log/zentyal/zentyal.log.4.gz to /var/log/zentyal/zentyal.log.5.gz (rotatecount 7, logstart 1, i 4),
renaming /var/log/zentyal/zentyal.log.3.gz to /var/log/zentyal/zentyal.log.4.gz (rotatecount 7, logstart 1, i 3),
renaming /var/log/zentyal/zentyal.log.2.gz to /var/log/zentyal/zentyal.log.3.gz (rotatecount 7, logstart 1, i 2),
renaming /var/log/zentyal/zentyal.log.1.gz to /var/log/zentyal/zentyal.log.2.gz (rotatecount 7, logstart 1, i 1),
renaming /var/log/zentyal/zentyal.log.0.gz to /var/log/zentyal/zentyal.log.1.gz (rotatecount 7, logstart 1, i 0),
old log /var/log/zentyal/zentyal.log.0.gz does not exist
renaming /var/log/zentyal/zentyal.log to /var/log/zentyal/zentyal.log.1
running postrotate script
 * Restarting Zentyal module: apache
   ...done.
 * Restarting Zentyal module: logs
   ...done.
 * Restarting Zentyal module: events
   ...done.
removing old log /var/log/zentyal/zentyal.log.8.gz
```
