### PR TITLE
Fixed s4sync's breakage when tries to sync serviceprincipals to OpenLDAP...

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Fixed s4sync's breakage when tries to sync serviceprincipals to
+	  OpenLDAP. Those users are ignored on EBox::LDB::users method
 	+ User profiles are only created if the OpenLDAP sync exists, otherwise,
 	  defer it until s4sync does the synchronization
 	+ Typo fix in netbios validation

--- a/main/samba/src/EBox/LDB.pm
+++ b/main/samba/src/EBox/LDB.pm
@@ -645,26 +645,11 @@ sub users
 
     my $list = [];
 
-    my $spFilter = $params{servicePrincipals} ? '' : '(!(servicePrincipalName=*))';
-    my $filter = "(&(&(objectclass=user)(!(objectclass=computer)))(!(isDeleted=*))$spFilter)";
-    my $params = {
-        base => $self->dn(),
-        scope => 'sub',
-        filter => $filter,
-        attrs => ['*', 'unicodePwd', 'supplementalCredentials'],
-    };
-
-    my $result = $self->search($params);
-    foreach my $entry ($result->sorted('samAccountName')) {
-        my $user = new EBox::Samba::User(entry => $entry);
-        push (@{$list}, $user);
-    }
-
     # Query the containers stored in the root DN and skip the ignored ones
     # Note that 'OrganizationalUnit' and 'msExchSystemObjectsContainer' are
     # subclasses of 'Container'.
     my @containers;
-    $params = {
+    my $params = {
         base => $self->dn(),
         scope => 'one',
         filter => '(objectClass=Container)',
@@ -678,13 +663,14 @@ sub users
     }
 
     # Query the users stored in the non ignored containers
+    my $spFilter = $params{servicePrincipals} ? '' : '(!(servicePrincipalName=*))';
+    my $filter = "(&(&(objectclass=user)(!(objectclass=computer)))(!(isDeleted=*))$spFilter)";
     foreach my $container (@containers) {
         $params = {
-            base => $container->dn(),
-            scope => 'sub',
-            filter => '(&(&(objectclass=user)(!(objectclass=computer)))' .
-                      '(!(isDeleted=*)))',
-            attrs => ['*', 'unicodePwd', 'supplementalCredentials'],
+            base   => $container->dn(),
+            scope  => 'sub',
+            filter => $filter,
+            attrs  => ['*', 'unicodePwd', 'supplementalCredentials'],
         };
         $result = $self->search($params);
         foreach my $entry ($result->sorted('samAccountName')) {


### PR DESCRIPTION
.... Those users are ignored on EBox::LDB::users method

This patch fixes a bad merge from 3.2 that was causing hiding the bugfix that was supposed to be implemented. It should fix the anste test: CheckSambaInternalUsersNotSynced from 3.3
