### PR TITLE
Check all fields are in params

### DIFF
--- a/main/core/src/EBox/CGI/Controller/DataTable.pm
+++ b/main/core/src/EBox/CGI/Controller/DataTable.pm
@@ -1,5 +1,5 @@
 # Copyright (C) 2007 Warp Networks S.L.
-# Copyright (C) 2008-2013 Zentyal S.L.
+# Copyright (C) 2008-2014 Zentyal S.L.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2, as
@@ -219,7 +219,10 @@ sub _editField
         }
 
         unless ($field->isa('EBox::Types::Boolean')) {
-            next unless (all($field->fields()) eq any(keys(%params)));
+            # Check all fields are in the params
+            my @fields = $field->fields();
+            my $seen = grep { defined ($params{$_})} @fields;
+            next if ($seen != scalar(@fields));
         }
 
         # Skip fields that are hidden or disabled by the view customizer


### PR DESCRIPTION
Without all and any as we need the defined value and not the key.

This prevented from table with read-only fields to work

No needed changelog as applies to:
    + Show complex types (more than one field) in audit log
      while editing by storing the dump of the value
