### PR TITLE
Hide openchange service status from the dashboard and linked it status t...

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Hide openchange service status from the dashboard and linked it status
+	  to the one from Samba
 3.2.3
 	+ Fixed a typo that makes openchange appear always off on Dashboard
 3.2.2

--- a/main/openchange/src/EBox/OpenChange.pm
+++ b/main/openchange/src/EBox/OpenChange.pm
@@ -169,6 +169,47 @@ sub _daemons
     return $daemons;
 }
 
+# Method: addModuleStatus
+#
+#   Hides Openchange from the Dashboard.
+#
+# Overrides: <EBox::Module::Service::addModuleStatus>
+#
+sub addModuleStatus
+{
+}
+
+# Method: showModuleStatus
+#
+#   Hides Openchange from the Dashboard.
+#
+# Overrides: <EBox::Module::Service::showModuleStatus>
+#
+sub showModuleStatus
+{
+    return 0;
+}
+
+# Method: isRunning
+#
+#   Links Openchange running status to Samba status.
+#
+# Overrides: <EBox::Module::Service::isRunning>
+#
+sub isRunning
+{
+    my ($self) = @_;
+
+    my $running = $self->SUPER::isRunning();
+
+    if ($running) {
+        my $sambaMod = $self->global()->modInstance('samba');
+        return $sambaMod->isRunning();
+    } else {
+        return $running;
+    }
+}
+
 sub _autodiscoverEnabled
 {
     my ($self) = @_;


### PR DESCRIPTION
...o the one from Samba

When this branch is merged into 3.3 the addModuleStatus and showModuleStatus overrides should be removed, just the isRunning override should remain.
