### PR TITLE
Improving zentyal-ppa-build to detect wrong KEY  for signing

### DIFF
--- a/extra/scripts/zentyal-ppa-build.sh
+++ b/extra/scripts/zentyal-ppa-build.sh
@@ -6,8 +6,28 @@
 # If a list of packages is passed by argument it
 # builds them instead of the modified.
 
-# Change this with your PPA key ID
-KEY_ID="19AD31B8"
+# Array of keys allowed to sign
+SIGN_KEYS=()
+SIGN_KEYS+=('F9FEF52C19AD31B8') # jacalvo
+SIGN_KEYS+=('38FD168F6F20BA36') # jenkins
+
+# Get the list of available keys
+SYSTEM_KEYS=($(gpg --list-public-keys --with-colons | awk -F ':' '{print $5}'))
+
+for ((i=0;i < ${#SIGN_KEYS[@]};i++)) {
+    K=${SIGN_KEYS[$i]}
+    for ((j=0; j < ${#SYSTEM_KEYS[@]}; j++)) {
+        S=${SYSTEM_KEYS[$j]}
+        if [ "$K" == "$S" ]; then
+            KEY_ID=$S
+        fi
+    }
+}
+
+if [ -z "$KEY_ID" ]; then
+    echo "Key not found!"
+    exit 1
+fi
 
 if [ $# -gt 0 ]
 then
@@ -22,7 +42,7 @@ do
     changelog="$i/debian/precise/changelog"
     git co $changelog
     echo "Building package $i..."
-    zentyal-package $i || exit 1
+    ../extra/zbuildtools/zentyal-package $i || exit 1
     cd debs-ppa
     dpkg-source -x zentyal-${i}_*.dsc || exit 1
     cd zentyal-${i}-*


### PR DESCRIPTION
And making the zentyal-ppa-build script to use the branch version of the script zentyal-package as suggested by @jacalvo 
