### PR TITLE
Moved to usercorner the AuthLDAP middleware and its dependencies

### DIFF
--- a/main/core/debian/control
+++ b/main/core/debian/control
@@ -14,9 +14,8 @@ Architecture: all
 Pre-Depends: mysql-server
 Depends: zentyal-common (>= 3.4~1), zentyal-common (<< 3.5),
          adduser, apport, anacron, cron, curl, dbus, debconf, gpgv,
-         haproxy (>= 1.5~dev13), libapt-pkg-perl, libauthen-simple-ldap-perl,
-         libauthen-simple-pam-perl, libcgi-emulate-psgi-perl,
-         libclass-singleton-perl, libclone-fast-perl, libcrypt-rijndael-perl,
+         haproxy (>= 1.5~dev13), libapt-pkg-perl, libauthen-simple-pam-perl,
+         libcgi-emulate-psgi-perl, libclass-singleton-perl, libclone-fast-perl,
          libdbd-mysql-perl, libfile-copy-recursive-perl, libfile-mmagic-perl,
          libfilesys-df-perl, libhttp-date-perl, libjson-perl,
          libjson-rpc-perl, libjson-xs-perl, liblexical-persistence-perl,

--- a/main/core/src/EBox/Middleware/Auth.pm
+++ b/main/core/src/EBox/Middleware/Auth.pm
@@ -26,10 +26,7 @@ use EBox::Config;
 use EBox::Exceptions::Internal;
 use EBox::Exceptions::Lock;
 
-use Crypt::Rijndael;
-use Digest::MD5;
 use Fcntl qw(:flock);
-use MIME::Base64;
 use Plack::Request;
 use Plack::Util::Accessor qw( app_name );
 use TryCatch::Lite;

--- a/main/usercorner/debian/control
+++ b/main/usercorner/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.2
 Package: zentyal-usercorner
 Architecture: all
 Depends: zentyal-core (>= 3.4~1), zentyal-core (<< 3.5), zentyal-users,
-         ${misc:Depends}
+         libauthen-simple-ldap-perl, libcrypt-rijndael-perl, ${misc:Depends}
 Description: Zentyal - User Corner
  Zentyal is a Linux small business server that can act as
  a Gateway, Unified Threat Manager, Office Server, Infrastructure

--- a/main/usercorner/src/EBox/UserCorner.pm
+++ b/main/usercorner/src/EBox/UserCorner.pm
@@ -25,8 +25,8 @@ use EBox::Exceptions::Internal;
 use EBox::Gettext;
 use EBox::Global;
 use EBox::Menu::Root;
-use EBox::Middleware::AuthLDAP;
 use EBox::UserCorner;
+use EBox::UserCorner::Middleware::AuthLDAP;
 use EBox::Util::Version;
 
 use constant USERCORNER_USER  => 'ebox-usercorner';
@@ -409,7 +409,7 @@ sub userCredentials
         throw EBox::Exceptions::Internal("There is no userDN information in the request object!");
     }
     my $userDN = $session->{userDN};
-    my $pass = EBox::Middleware::AuthLDAP->sessionPassword($request);
+    my $pass = EBox::UserCorner::Middleware::AuthLDAP->sessionPassword($request);
     unless (defined $pass) {
         throw EBox::Exceptions::Internal("There is password defined for this request object!");
     }

--- a/main/usercorner/src/EBox/UserCorner/Middleware/AuthLDAP.pm
+++ b/main/usercorner/src/EBox/UserCorner/Middleware/AuthLDAP.pm
@@ -16,7 +16,7 @@
 use strict;
 use warnings;
 
-package EBox::Middleware::AuthLDAP;
+package EBox::UserCorner::Middleware::AuthLDAP;
 use base qw(EBox::Middleware::Auth);
 
 use EBox;

--- a/main/usercorner/src/psgi/usercorner.psgi
+++ b/main/usercorner/src/psgi/usercorner.psgi
@@ -54,7 +54,7 @@ builder {
     enable "Session",
         state   => 'Plack::Session::State::Cookie',
         store   => new Plack::Session::Store::File(dir => SESSIONS_PATH);
-    enable "+EBox::Middleware::AuthLDAP", app_name => 'usercorner';
+    enable "+EBox::UserCorner::Middleware::AuthLDAP", app_name => 'usercorner';
     $app;
 };
 

--- a/main/users/src/EBox/Users/Model/Password.pm
+++ b/main/users/src/EBox/Users/Model/Password.pm
@@ -27,7 +27,6 @@ use base 'EBox::Model::DataForm';
 use EBox::Exceptions::External;
 use EBox::Exceptions::Internal;
 use EBox::Gettext;
-use EBox::Middleware::AuthLDAP;
 use EBox::Users::Types::Password;
 use EBox::Validate qw(:all);
 
@@ -187,7 +186,8 @@ sub setTypedRow
     $zentyalUser->changePassword($pass1->value());
 
     # FIXME: Hide this inside a method on EBox::UserCorner
-    EBox::Middleware::AuthLDAP->updateSessionPassword($global->request(), $pass1->value());
+    use EBox::UserCorner::Middleware::AuthLDAP;
+    EBox::UserCorner::Middleware::AuthLDAP->updateSessionPassword($global->request(), $pass1->value());
 
     $self->setMessage(__('Password successfully updated'));
 }


### PR DESCRIPTION
Finally is not possible to share the AuthLDAP middleware between captive portal and user corner, so makes no sense to keep the usercorner's auth middleware inside the core package. This patch moves it to usercorner with its dependencies.

```
User Corner Test Suite
    InstallNonProfilePackages: OK
    EnableUsersZentyalTest: OK
    AddUser: OK
    Check-Login: OK
    Change-Password: OK
    Check-Login-failed: OK
    Check-Login-success: OK
    check-zentyal-log: OK
    check-syslog-apparmor: OK
```
