### PR TITLE
Fix tab selection in tabbed composite from URL path anchor

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Fix tab selection in tabbed composite from URL path anchor,
+	  for instance, /Maintenance/Events#ConfigureDispatchers
 	+ Avoid errors triggered on web administration port validation
 	+ ManageAdmins model now also add/removes lpadmin group
 3.2.7

--- a/main/core/src/templates/ajax/tabMenu.mas
+++ b/main/core/src/templates/ajax/tabMenu.mas
@@ -83,11 +83,13 @@ use EBox::Gettext;
   );
   var url = location.href.split('#');
   if ( url[1] ) {
-     var activeTab = tabMenu_<% $tabName | hu %>.tabs.detect(
+     var activeTabs = $.grep(tabMenu_<% $tabName | hu %>.tabs,
         function (t) {
              return t.href.split('#')[1] == url[1];
         }
      );
-     tabMenu_<% $tabName | hu %>.showActiveTab(activeTab);
+     if (activeTabs.length > 0) {
+        tabMenu_<% $tabName | hu %>.showActiveTab(activeTabs[0]);
+     }
   }
 </script>

--- a/main/core/www/js/tabMenu.js
+++ b/main/core/www/js/tabMenu.js
@@ -138,9 +138,9 @@ Zentyal.Tabs.prototype = {
     } else {
         // Hide the no-active tabs
         this.tabs.not(tab).removeClass(this.activeClassName);
-        this.activeTab = tab;
+        this.activeTab = $(tab);
         // Show the tab
-        tab.addClass(this.activeClassName);
+        this.activeTab.addClass(this.activeClassName);
         // Set the correct form values
         var activeTabDir = this.modelAttrs[this.activeTab.attr('id')].directory;
         this._setTableFormInput('directory', activeTabDir);
@@ -149,7 +149,7 @@ Zentyal.Tabs.prototype = {
         // Load the content from table-helper
         Zentyal.TableHelper.hangTable( 'tabData_' + this.tabName ,
                    'errorTabData_' + this.tabName,
-                   this.modelAttrs[ tab.attr('id') ].action,
+                   this.modelAttrs[ this.activeTab.attr('id') ].action,
                    'tableForm',
                    'tabData_' + this.tabName);
     }


### PR DESCRIPTION
For instance, /Maintenance/Events#ConfigureDispatchers goes directly to that composite.

Regression in the transition from prototype to jQuery.
