### PR TITLE
Fixes on cluster status

### DIFF
--- a/main/ha/src/EBox/HA/ClusterStatus.pm
+++ b/main/ha/src/EBox/HA/ClusterStatus.pm
@@ -472,8 +472,13 @@ sub _parseResources
                            managed => ($xmlResource->getAttribute('managed') eq 'true'),
                            failed => ($xmlResource->getAttribute('failed') eq 'true'),
                            failure_ignored => ($xmlResource->getAttribute('failure_ignored') eq 'true'),
-                           nodes_running_on => $xmlResource->getAttribute('nodes_running_on'),
+                           nodes_running_on => $xmlResource->getAttribute('nodes_running_on'),  # Number of nodes running this resource
                          };
+        # Store the nodes we are running on
+        if ($resources{$name}->{nodes_running_on} > 0) {
+            my @nodes = map { $_->getAttribute('id') } $xmlResource->findnodes('./node');
+            $resources{$name}->{nodes} = \@nodes;
+        }
     }
 
     return \%resources;

--- a/main/ha/src/EBox/HA/Model/Errors.pm
+++ b/main/ha/src/EBox/HA/Model/Errors.pm
@@ -30,22 +30,6 @@ use EBox::HA::ClusterStatus;
 
 # Group: Public methods
 
-# Constructor: new
-#
-#    To store the list
-#
-sub new
-{
-    my $class = shift;
-
-    my $self = $class->SUPER::new(@_);
-    bless($self, $class);
-
-    $self->{clusterStatus} = new EBox::HA::ClusterStatus($self->parentModule());
-
-    return $self;
-}
-
 # Method: ids
 #
 #     Return the current list of node names
@@ -57,6 +41,8 @@ sub new
 sub ids
 {
     my ($self)  = @_;
+
+    $self->{clusterStatus} = new EBox::HA::ClusterStatus($self->parentModule());
 
     unless (defined($self->{clusterStatus}->errors())) {
         return [];

--- a/main/ha/src/EBox/HA/Model/NodeStatus.pm
+++ b/main/ha/src/EBox/HA/Model/NodeStatus.pm
@@ -31,22 +31,6 @@ use EBox::Types::Host;
 
 # Group: Public methods
 
-# Constructor: new
-#
-#    To store the list
-#
-sub new
-{
-    my $class = shift;
-
-    my $self = $class->SUPER::new(@_);
-    bless($self, $class);
-
-    $self->{clusterStatus} = new EBox::HA::ClusterStatus($self->parentModule());
-
-    return $self;
-}
-
 # Method: ids
 #
 #     Return the current list of node names
@@ -58,6 +42,8 @@ sub new
 sub ids
 {
     my ($self)  = @_;
+
+    $self->{clusterStatus} = new EBox::HA::ClusterStatus($self->parentModule());
 
     unless (defined($self->{clusterStatus}->nodes())) {
         return [];
@@ -173,11 +159,13 @@ sub _parseNode_floating
         my %resource = %{ $resources{$key} };
 
         if ($resource{'resource_agent'} eq 'ocf::heartbeat:IPaddr2') {
-            my %managingNode = %{ $self->{clusterStatus}->nodeById($resource{'managed'}) };
+            foreach my $nodeId (@{$resource{'nodes'}}) {
+                my $managingNode = $self->{clusterStatus}->nodeById($nodeId);
 
-            if ($node{'name'} eq $managingNode{'name'}) {
-                if ($result) { $result = $result . " - "; }
-                $result = $result . $resource{'id'} . " ";
+                if ($node{'name'} eq $managingNode->{'name'}) {
+                    $result = $result . " - " if ($result);
+                    $result = $result . $resource{'id'} . " ";
+                }
             }
         }
     }

--- a/main/ha/src/EBox/HA/Model/ResourceStatus.pm
+++ b/main/ha/src/EBox/HA/Model/ResourceStatus.pm
@@ -30,22 +30,6 @@ use EBox::HA::ClusterStatus;
 
 # Group: Public methods
 
-# Constructor: new
-#
-#    To store the list
-#
-sub new
-{
-    my $class = shift;
-
-    my $self = $class->SUPER::new(@_);
-    bless($self, $class);
-
-    $self->{clusterStatus} = new EBox::HA::ClusterStatus($self->parentModule());
-
-    return $self;
-}
-
 # Method: ids
 #
 #     Return the current list of resource names
@@ -57,6 +41,8 @@ sub new
 sub ids
 {
     my ($self)  = @_;
+
+    $self->{clusterStatus} = new EBox::HA::ClusterStatus($self->parentModule());
 
     unless (defined($self->{clusterStatus}->resources())) {
         return [];
@@ -154,9 +140,10 @@ sub _parseResource_started
 {
     my ($self, %resource) = @_;
 
-    my %managingNode = %{ $self->{clusterStatus}->nodeById($resource{'managed'}) };
+    my $nodes = $resource{'nodes'};
+    my @nodeNames = map { $self->{clusterStatus}->nodeById($_)->{'name'} } @{$nodes};
 
-    return $managingNode{'name'};
+    return join(', ', @nodeNames);
 }
 
 1;


### PR DESCRIPTION
- Resources now stores where they are running on 'nodes' attr
- cluster status is gathered on ids method as constructor
  is set by model manager only once, then no refresh were done
- Fix models to know where a resource is running on
