### PR TITLE
Fixed bad behaviour in interfaces method wizard

### DIFF
--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fixed bad behaviour in interfaces method wizard
 	+ Don't generate resolvconf file until all interfaces are up
 	+ nameservers() method always return 127.0.0.1 if DNS module is
 	  installed and enabled

--- a/main/network/src/templates/wizard/network.mas
+++ b/main/network/src/templates/wizard/network.mas
@@ -5,7 +5,7 @@
 <%init>
 use EBox::Gettext;
 
-my @ifaces = ( @extifaces, @intifaces );
+my @ifaces = sort ( @extifaces, @intifaces );
 my $numExt = scalar @extifaces;
 my $counter = 0;
 


### PR DESCRIPTION
3.4 seems not be affected but only per change.. it seems that it somewhat returns the interfaces in correct order, I think we can port-forward this for more security
