### PR TITLE
Ignored failures that are already catched inside the application and not...

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,5 +1,5 @@
 3.4
-	+ Increaded the buffer size for uwsgi applications to allow big submits
+	+ Increased the buffer size for uwsgi applications to allow big submits
 	  like the one from automatic error report
 	+ Added a UnhandledError middleware to catch any die or exception not
 	  handled by Zentyal

--- a/main/core/src/EBox/Middleware/UnhandledError.pm
+++ b/main/core/src/EBox/Middleware/UnhandledError.pm
@@ -66,14 +66,19 @@ sub call
     };
 
     my $res;
+    my $caught = 0;
     try {
         $res = $self->app->($env);
     } catch ($e) {
+        $caught = 1;
         # This $res will only be used if $trace is undef
         $res = [500, ['Content-Type' => 'text/plain; charset=utf-8'], [no_trace_error($e)]];
     }
 
-    if ($trace) {
+    # The __DIE__ endpoint may catch exceptions that are not valid ones, for instance, an eval to check if a package
+    # is available. In those cases, the application will not break and thus we should not fail and print the
+    # backtrace.
+    if ($caught and $trace) {
         $res = [500, ['Content-Type' => 'text/html; charset=utf-8'], [$trace->as_html()]];
     }
 


### PR DESCRIPTION
... re-raised

Captive Portal Test Suite
        InstallNonProfilePackages: OK
        EnableModules: OK
        TestSetCaptiveInteface: OK
        TestSetCaptivePortalGeneralSettings: OK
        TestAddCaptivePortalException: OK
        TestAddCaptivePortalException: OK
        SaveChanges: OK
        TestIPTablesExceptions: OK
        AddUser: OK
        TestAuth: OK
        TestIPTablesRulesForUser: OK
        TestKickUser: OK
        TestIPTablesRulesForUserHaveBeenRemoved: OK
        check-zentyal-log: OK
        check-syslog-apparmor: OK
