### PR TITLE
Fixed file upload

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,6 @@
 3.4
+	+ Removed EBox::Base::upload method because that's 100% handled by Plack
+	  now.
 	+ Increased the buffer size for uwsgi applications to allow big submits
 	  like the one from automatic error report
 	+ Added a UnhandledError middleware to catch any die or exception not

--- a/main/core/src/EBox/CGI/Base.pm
+++ b/main/core/src/EBox/CGI/Base.pm
@@ -941,54 +941,6 @@ sub masonParameters
     return [];
 }
 
-# Method: upload
-#
-#  Upload a file from the client computer. The file is place in
-#  the tmp directory (/tmp)
-#
-#
-# Parameters:
-#
-#   uploadParam - String request parameter name which contains the path to the
-#   file which will be uploaded. It is usually obtained from a HTML
-#   file input
-#
-# Returns:
-#
-#   String - the path of the uploaded file
-#
-# Exceptions:
-#
-#   <EBox::Exceptions::Internal> - thrown if an error has happened
-#   within the request or it is impossible to read the upload file or the
-#   parameter does not pass on the request
-#
-#   <EBox::Exceptions::External> - thrown if there is no file to
-#   upload or cannot create the temporally file
-#
-sub upload
-{
-    my ($self, $uploadParam) = @_;
-    defined $uploadParam or throw EBox::Exceptions::MissingArgument('uploadParam');
-
-    # upload parameter...
-    my $request = $self->request();
-    my $uploads = $request->uploads();
-    my $upload = $uploads->{$uploadParam};
-    if (not defined $upload) {
-        # FIXME: We should add upload error handling for Plack / PSGI.
-        throw EBox::Exceptions::Internal("The upload parameter $uploadParam does not "
-                . 'pass on HTTP request');
-    }
-
-    # get upload contents temp file path
-    unless ($upload->path()) {
-        throw EBox::Exceptions::External( __('Invalid uploaded file.'));
-    }
-
-    return $upload->path();
-}
-
 # Method: setMenuNamespace
 #
 #   Set the menu namespace to help the menu code to find out

--- a/main/core/src/EBox/CGI/Uploader.pm
+++ b/main/core/src/EBox/CGI/Uploader.pm
@@ -57,21 +57,22 @@ sub _process
 {
     my $self = shift;
 
-    my $params = $self->params();
+    my $request = $self->request();
+    my $uploads = $request->uploads();
+    my @entryKeys = keys %{$uploads};
 
-    my $filePathParam = $params->[0];
-    my $uploadedFile = $self->upload($filePathParam);
-
-    my ($baseTmp, $tmpDir) = fileparse($uploadedFile);
-
+    # We only take the first uploaded file found.
+    my $upload = $uploads->{$entryKeys[0]};
+    my $uploadedFile = $upload->path();
+    my $basename = $entryKeys[0];
     # Remove the model name to get just the field name
-    $filePathParam =~ s/^.*?_//g;
+    $basename =~ s/^.*?_//g;
+    my $tmpDir = EBox::Config::tmp();
 
     # Rename to the user-defined file name
-    move($uploadedFile, $tmpDir . $filePathParam) or
-      throw EBox::Exceptions::Internal("Cannot move $uploadedFile to "
-                                       . $tmpDir . $filePathParam
-                                       . " $!");
+    unless (move($uploadedFile, $tmpDir . $basename)) {
+        throw EBox::Exceptions::Internal("Cannot move $uploadedFile to ${tmpDir}${basename} $!");
+    }
 
 }
 

--- a/main/core/src/EBox/SysInfo/CGI/ConfirmBackup.pm
+++ b/main/core/src/EBox/SysInfo/CGI/ConfirmBackup.pm
@@ -124,7 +124,11 @@ sub  restoreFromFileAction
   if ($self->param('alreadyUploaded')) {
       $filename = $self->param('backupfile');
   } else {
-      $filename = $self->upload('backupfile');
+      my $request = $self->request();
+      my $uploads = $request->uploads();
+
+      my $upload = $uploads->{backupfile};
+      my $filename = $upload->path();
   }
 
   my $details = $self->backupDetailsFromFile($filename);


### PR DESCRIPTION
The tests work with a workaround, you need to copy qa/server-tests/files/shallalist.tar.gz to /tmp or the SetDomainList tests will fail. I'm checking with Julio if it's a bug in the test itself or in anste. Other than that, with the changes here, the upload works again.

Zentyal Proxy objects and domain lists tests
        EnableModules: OK
        ConfigNetworkSetExternal: OK
        TestDeleteAccessRule: OK
        TestCreateProfile: OK
        ContentFilterStrict: OK
        SetDomainList: OK
        ConfigureDomainListAllowPorn: OK
        ConfigureDomainListFilterAstronomy: OK
        TestAllowPornDomain: OK
        TestDeniedAstronomyDomain: OK
        TestRemoveDomainListsFiles: OK
        SetDomainList: OK
        TestAllowPornDomain: OK
        TestDeniedAstronomyDomain: OK
        RemoveDomainListPorn: OK
        TestAllowAstronomyDomain: OK
        TestDomainListsFiles: OK
        check-zentyal-log: OK
        check-syslog-apparmor: OK
