### PR TITLE
Fix remoteservices initial-setup on fresh install

### DIFF
--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ On initial setup, do only reload bundle and restart the service
+	  if the server is registered
 	+ Fix warning on last inside an eval on automatic-conf-backup script
 3.2.3
 	+ Adapted to new AJAX update of save changes button

--- a/main/remoteservices/src/EBox/RemoteServices.pm
+++ b/main/remoteservices/src/EBox/RemoteServices.pm
@@ -183,15 +183,18 @@ sub initialSetup
     my ($self, $version) = @_;
 
     if (defined ($version)) {
-        # Reload bundle without forcing
-        $self->reloadBundle(0);
+        # Upgrading...
+        if ($self->eBoxSubscribed()) {
+            # Reload bundle without forcing
+            $self->reloadBundle(0);
+            # Restart the service
+            unless (-e '/var/lib/zentyal/tmp/upgrade-from-CC') {
+                $self->restartService();
+            }
+        }
     }
 
     EBox::Sudo::root('chown -R ebox:adm ' . EBox::Config::conf() . 'remoteservices');
-
-    unless (-e '/var/lib/zentyal/tmp/upgrade-from-CC') {
-        $self->restartService();
-    }
 }
 
 sub _setRemoteSupportAccessConf


### PR DESCRIPTION
- On initial setup, do only reload bundle and restart the service if the server is registered
