### PR TITLE
Catch not found when trying to delete a non-existing subapp

### DIFF
--- a/main/remoteservices/src/EBox/RemoteServices.pm
+++ b/main/remoteservices/src/EBox/RemoteServices.pm
@@ -1726,9 +1726,10 @@ sub _confSOAPService
             $webAdminMod->addCA($self->_caCertPath());
         }
     } else {
-        # Do nothing if CA or the sub-app are already removed
+        # Do nothing if CA or the sub-apps are already removed
         try {
             EBox::WebAdmin::PSGI::removeSubApp('/soap');
+            EBox::WebAdmin::PSGI::removeSubApp('/ebox');
             $webAdminMod->removeCA($self->_caCertPath('force'));
         } catch (EBox::Exceptions::Internal $e) {
         } catch (EBox::Exceptions::DataNotFound $e) {


### PR DESCRIPTION
This happens on two cases:
- upgrade on non-registered servers
- launching restart of the module without being registered.
