### PR TITLE
Revert "temporary removal of automatic remoteservices selection"

### DIFF
--- a/main/software/src/templates/ebox.mas
+++ b/main/software/src/templates/ebox.mas
@@ -513,12 +513,9 @@ $(function() {
    $('#advanced').show();
 % }
 
-// FIXME: uncomment this before 3.4 is released
-/*
    if ($('#zentyal-remoteservices').length > 0) {
         Zentyal.SoftwareManagementUI.selectPackage('zentyal-remoteservices');
    }
-*/
 
    $('#updNumber').html( '<% scalar @advUpdatePkgs %>' );
    // update button status

--- a/main/software/www/js/software-management.js
+++ b/main/software/www/js/software-management.js
@@ -2,16 +2,15 @@
 
 Zentyal.namespace('SoftwareManagementUI');
 
-// FIXME: add zentyal-remoteservices before 3.4 is released
 Zentyal.SoftwareManagementUI.suites =  {
     'Gateway' : [ 'zentyal-network', 'zentyal-firewall', 'zentyal-squid', 'zentyal-trafficshaping', 'zentyal-l7-protocols',
-                  'zentyal-users', 'zentyal-monitor', 'zentyal-ca', 'zentyal-openvpn' ],
+                  'zentyal-users', 'zentyal-remoteservices', 'zentyal-monitor', 'zentyal-ca', 'zentyal-openvpn' ],
     'Infrastructure' : [ 'zentyal-network', 'zentyal-firewall', 'zentyal-dhcp', 'zentyal-dns', 'zentyal-openvpn',
-                         'zentyal-webserver', 'zentyal-ftp', 'zentyal-ntp', 'zentyal-ca' ],
+                         'zentyal-webserver', 'zentyal-ftp', 'zentyal-ntp', 'zentyal-ca', 'zentyal-remoteservices' ],
     'Office' : [ 'zentyal-samba', 'zentyal-printers', 'zentyal-antivirus', 'zentyal-users', 'zentyal-firewall',
-                 'zentyal-network', 'zentyal-ca', 'zentyal-openvpn', 'zentyal-monitor' ],
+                 'zentyal-network', 'zentyal-remoteservices', 'zentyal-ca', 'zentyal-openvpn', 'zentyal-monitor' ],
     'Communications' : [ 'zentyal-mail', 'zentyal-jabber', 'zentyal-mailfilter', 'zentyal-users', 'zentyal-ca',
-                         'zentyal-firewall', 'zentyal-network', 'zentyal-openvpn', 'zentyal-monitor' ]
+                         'zentyal-firewall', 'zentyal-network', 'zentyal-remoteservices', 'zentyal-openvpn', 'zentyal-monitor' ]
 };
 
 Zentyal.SoftwareManagementUI.showInstallTab = function() {


### PR DESCRIPTION
This reverts commit c8f5d09688882649eb2ec9cb3a08dbd2b2d05137.

As _zentyal-remoteservices_ is now working on installation.
