### PR TITLE
Allow antivirus nto pass non scanned files to void issues when editing

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Change Allow_non_scanned_files on samba.conf as default to 
+	  avoid issues with antivirus when editing files.
 	+ Set OpenChange as not provisioned when Samba is reprovisioned
 	+ Added a way to check whether we are managing the AD schema or not
 	+ Samba provision failures when IPs are not set no longer talk

--- a/main/samba/conf/samba.conf
+++ b/main/samba/conf/samba.conf
@@ -95,7 +95,7 @@ recheck_tries_open = 100
 
 # Allow access to non-scanned files. The daemon is notified, however, and special files such
 # as .scanned: files. .virus: files and .failed: files are not listed.
-allow_nonscanned_files = False
+allow_nonscanned_files = True
 
 # Number of threads used to scan files
 scanning_threads = 4


### PR DESCRIPTION
files, mainly with CAD and MS Office files
