### PR TITLE
EBox::Samba::LdbObject::setCritical cannot use lazy flag to work correct...

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ EBox::Samba::LdbObject::setCritical cannot use lazy flag to work
+	  correctly
 3.2.14
 	+ Fix NT_STATUS_ACCESS_DENIED opening files quering the DOS attributes
 	  and passing them to open function

--- a/main/samba/src/EBox/Samba/LdbObject.pm
+++ b/main/samba/src/EBox/Samba/LdbObject.pm
@@ -322,9 +322,14 @@ sub _stringToGuid
            pack("C", hex $10) . pack("C", hex $11);
 }
 
+# Method: setCritical
+#
+#   Tags / untags the object as a critical system object.
+#   This method doesn't support the lazy flag because it requires to relax restrictions to apply this change.
+#
 sub setCritical
 {
-    my ($self, $critical, $lazy) = @_;
+    my ($self, $critical) = @_;
 
     if ($critical) {
         $self->set('isCriticalSystemObject', 'TRUE', 1);
@@ -335,7 +340,7 @@ sub setCritical
     my $relaxOidControl = Net::LDAP::Control->new(
         type => '1.3.6.1.4.1.4203.666.5.12',
         critical => 0 );
-    $self->save($relaxOidControl) unless $lazy;
+    $self->save($relaxOidControl);
 }
 
 sub isInAdvancedViewOnly


### PR DESCRIPTION
...ly

This change is required to fix recent anste test broken on 3.4. I'm applying this change to 3.2 because the API is broken here too, although we are not using the broken flag here and that's why only 3.4 is affected.
