### PR TITLE
Pinning kernels so they are updated with QA updates active

### DIFF
--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Pinning kernels so they are updated with QA updates active
 	+ Fix warning on last inside an eval on automatic-conf-backup script
 3.0.28
 	+ Update support information due to offer 2013

--- a/main/remoteservices/stubs/qa-preferences.mas
+++ b/main/remoteservices/stubs/qa-preferences.mas
@@ -9,6 +9,22 @@ Package: *
 Pin: release a=now
 Pin-Priority: 500
 
+Package: linux-image*
+Pin: release *
+Pin-Priority: 500
+
+Package: linux-headers*
+Pin: release *
+Pin-Priority: 500
+
+Package: linux-generic*
+Pin: release *
+Pin-Priority: 500
+
+Package: linux-firmware
+Pin: release *
+Pin-Priority: 500
+
 Package: *
 Pin: release *
 Pin-Priority: 50


### PR DESCRIPTION
Conflicts:
    main/remoteservices/ChangeLog
