### PR TITLE
vsftp 3.0 allows chrootUsers activation

### DIFF
--- a/main/ftp/ChangeLog
+++ b/main/ftp/ChangeLog
@@ -1,4 +1,5 @@
 3.4
+	+ Enabled the chrootUsers option
 	+ Set version to 3.4
 3.3
 	+ Disable seccomp sandboxing in the conf to avoid errors

--- a/main/ftp/src/EBox/FTP.pm
+++ b/main/ftp/src/EBox/FTP.pm
@@ -203,9 +203,7 @@ sub _setConf
     my $anonymous = $options->anonymous();
     my $userHomes = $options->userHomes();
 
-    # disabled until vsftpd allows it, see #4113
-    # my $chrootUsers = $options->chrootUsers();
-    my $chrootUsers = 0;
+    my $chrootUsers = $options->chrootUsers();
 
     my $ssl = $options->ssl();
 


### PR DESCRIPTION
Zentyal 3.4 ships a vsftp package that works again with the users chroot option so we are able to enable it again. I added anste tests to confirm it:

Zentyal FTP tests
    ConfigNetSetExternal: OK
    InstallFTP: OK
    EnableModules: OK
    AddUser: OK
    ConfigFTPNonSSLNonAnonymous: OK
    TestPut: OK
    TestGet: OK
    TestPwd: OK
    ConfigFTPNonSSLAnonymousReadWrite: OK
    TestPutAnonymous: OK
    TestGetAnonymous: OK
    ConfigFTPNonSSLAnonymousReadOnly: OK
    TestPutAnonymousReadOnly: OK
    TestGetAnonymousReadOnly: OK
    ConfigFTPNonSSLNonAnonymousWithChroot: OK
    TestPut: OK
    TestGet: OK
    TestPwd: OK
    check-zentyal-log: OK
    check-syslog-apparmor: OK
