### PR TITLE
vsftp 3.0 allows chrootUsers activation

### DIFF
--- a/main/ftp/ChangeLog
+++ b/main/ftp/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Fix the enabling of the chrootUsers option
 3.2.1
 	+ Force depend on PPA version of vsftpd with the chroot patch
 	+ Added Support for chrooting users

--- a/main/ftp/src/EBox/FTP.pm
+++ b/main/ftp/src/EBox/FTP.pm
@@ -208,9 +208,7 @@ sub _setConf
     my $anonymous = $options->anonymous();
     my $userHomes = $options->userHomes();
 
-    # disabled until vsftpd allows it, see #4113
-    # my $chrootUsers = $options->chrootUsers();
-    my $chrootUsers = 0;
+    my $chrootUsers = $options->chrootUsers();
 
     my $ssl = $options->ssl();
 


### PR DESCRIPTION
After running new anste tests for FTP with the same fix I did for master branch I found that 3.2 and later are really working with FTP chrootUser option, so this is an adaptation of the change done for the master branch:

```
Zentyal FTP tests
    ConfigNetSetExternal: OK
    InstallFTP: OK
    EnableModules: OK
    AddUser: OK
    ConfigFTPNonSSLNonAnonymous: OK
    TestPut: OK
    TestGet: OK
    TestPwd: OK
    ConfigFTPNonSSLAnonymousReadWrite: OK
    TestPutAnonymous: OK
    TestGetAnonymous: OK
    ConfigFTPNonSSLAnonymousReadOnly: OK
    TestPutAnonymousReadOnly: OK
    TestGetAnonymousReadOnly: OK
    ConfigFTPNonSSLNonAnonymousWithChroot: OK
    TestPut: OK
    TestGet: OK
    TestPwd: OK
    check-zentyal-log: OK
    check-syslog-apparmor: OK
```
