### PR TITLE
Use module global instead of always read-only in ddns conf gen

### DIFF
--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Fix Dynamic DNS with Zentyal Remote as provider when the
+	  registration wizard is done
 3.2.5
 	+ Wait a bit in multigwRoutes to give time to dhcp/pppoe to register addresses
 	+ Don't generate resolvconf file until all interfaces are up

--- a/main/network/src/EBox/Network.pm
+++ b/main/network/src/EBox/Network.pm
@@ -2922,7 +2922,7 @@ sub _generateDDClient
 
     if ($enabled) {
         if ( $row->valueByName('service') eq 'cloud' ) {
-            my $gl = EBox::Global->getInstance(1);
+            my $gl = $self->global();
             if ( $gl->modExists('remoteservices') ) {
                 my $rs = $gl->modInstance('remoteservices');
                 if ( $rs->eBoxSubscribed() ) {


### PR DESCRIPTION
- Fix Dynamic DNS with Zentyal Remote as provider when the
  registration wizard is done
