### PR TITLE
Prevent that we unset the mail if it's not changed and stop removing the...

### DIFF
--- a/main/users/src/EBox/Users/CGI/EditUser.pm
+++ b/main/users/src/EBox/Users/CGI/EditUser.pm
@@ -97,11 +97,16 @@ sub _process
                 $user->delete('description', 1);
             }
             my $mail = $self->unsafeParam('mail');
-            if (length ($mail) and ($mail ne $user->get('mail'))) {
-                $user->checkMail($mail);
-                $user->set('mail', $mail, 1);
+            if (length ($mail)) {
+                if ($mail ne $user->get('mail')) {
+                    $user->checkMail($mail);
+                    $user->set('mail', $mail, 1);
+                }
             } else {
-                $user->delete('mail', 1);
+                # FIXME: We cannot delete the field if empty because if zentyal-mail is activated we will get an LDAP
+                # error because the schema requires this field. We should implement a way so this field is not optional
+                # with zentyal-mail installed
+                $user->set('mail', '', 1);
             }
 
             $user->set('givenname', $givenName, 1);


### PR DESCRIPTION
... field or zentyal-mail breaks as a workaround to the fact that the mail field is optional even if zentyal-mail requires it

It fixes the new added tests to the POP/IMAP test suite: (EditUser and EditUserWithEmptyMail)

```
POP/IMAP tests suite
    ConfigNetworkSetExternal: OK
    EnableModules: OK
    RemoveGateway: OK
    AddGateway: OK
    AddUser: OK
    CreateVDomain: OK
    SaveChanges1: OK
    SetEmailAccount: OK
    SetupRouter: OK
    EnablePOP: OK
    Test-POP-internal: OK
    Test-POP-external: OK
    Test-NOT-POPS-internal: OK
    Test-NOT-POPS-external: OK
    Test-NOT-IMAP-internal: OK
    Test-NOT-IMAP-external: OK
    Test-NOT-IMAPS-internal: OK
    Test-NOT-IMAPS-external: OK
    EnablePOPS: OK
    Test-NOT-POP-internal: OK
    Test-NOT-POP-external: OK
    Test-POPS-internal: OK
    Test-POPS-external: OK
    Test-NOT-IMAP-internal: OK
    Test-NOT-IMAP-external: OK
    Test-NOT-IMAPS-internal: OK
    Test-NOT-IMAPS-external: OK
    EnableIMAP: OK
    Test-NOT-POP-internal: OK
    Test-NOT-POP-external: OK
    Test-NOT-POPS-internal: OK
    Test-NOT-POPS-external: OK
    Test-IMAP-internal: OK
    Test-IMAP-external: OK
    Test-NOT-IMAPS-internal: OK
    Test-NOT-IMAPS-external: OK
    EnableIMAPS: OK
    Test-NOT-POP-internal: OK
    Test-NOT-POP-external: OK
    Test-NOT-POPS-internal: OK
    Test-NOT-POPS-external: OK
    Test-NOT-IMAP-internal: OK
    Test-NOT-IMAP-external: OK
    Test-IMAPS-internal: OK
    Test-IMAPS-external: OK
            EditUser: OK
    EditUserWithEmptyMail: OK
    check-zentyal-log: OK
    check-syslog-apparmor: OK
```
