### PR TITLE
Hide passwords on admin user model on error and debug on

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Hide passwords on admin user model on error and debug on
 3.3.6
 	+ Zentyal MySQL custom conf is now written on initial-setup of logs
 	  using a mason template

--- a/main/core/src/EBox/SysInfo/Model/AdminUser.pm
+++ b/main/core/src/EBox/SysInfo/Model/AdminUser.pm
@@ -104,19 +104,20 @@ sub _doChangePassword
     }
 
     unless (defined ($newpwd1) and defined ($newpwd2)) {
-        throw EBox::Exceptions::DataMissing(data => __('New password'));
+        throw EBox::Exceptions::DataMissing(data => __('New password'), silent => 1);
     }
 
     unless ($newpwd1 eq $newpwd2) {
-        throw EBox::Exceptions::External(__('New passwords do not match.'));
+        throw EBox::Exceptions::External(__('New passwords do not match.'), silent => 1);
     }
 
     unless (length ($newpwd1) > 5) {
-        throw EBox::Exceptions::External(__('The password must be at least 6 characters long'));
+        throw EBox::Exceptions::External(__('The password must be at least 6 characters long'),
+                                         silent => 1);
     }
 
     unless (EBox::Auth->checkValidUser($username, $curpwd)) {
-        throw EBox::Exceptions::External(__('Incorrect current password.'));
+        throw EBox::Exceptions::External(__('Incorrect current password.'), silent => 1);
     }
 
     EBox::Auth->setPassword($username, $newpwd1);


### PR DESCRIPTION
As they are external exceptions are shown to the user without dumping it to the log
