### PR TITLE
Added http_allow to internal squid stub so proxy event does not need

### DIFF
--- a/main/squid/ChangeLog
+++ b/main/squid/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+  Added http_allow rule to avoid having to add an explicit rule for
+	 proxy events
 3.0.17
 	+ Make external AD auth available for offer 2013
 3.0.16

--- a/main/squid/stubs/squid.conf.mas
+++ b/main/squid/stubs/squid.conf.mas
@@ -280,6 +280,7 @@ acl <% "$name $params" %>
 
 http_access allow to_localhost
 follow_x_forwarded_for allow from_localhost
+http_access allow from_localhost
 forwarded_for on
 log_uses_indirect_client on
 always_direct allow to_localhost


### PR DESCRIPTION
an explicit rule (Backported from 3.2
https://github.com/Zentyal/zentyal/commit/b868d9b7c52507c52c5ee6f5c247ecacb378d572)
