### PR TITLE
Avoid race conditions whit captiveportal when restarting firewall

### DIFF
--- a/main/captiveportal/ChangeLog
+++ b/main/captiveportal/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Stop captive portal on firewall restart
 	+ Better packaging for EBox::Event::Watcher::CaptivePortalQuota
 	+ Fixed restricted login by group
 	+ Don't show iptables error on Captive Daemon if debug is not enabled

--- a/main/captiveportal/src/EBox/CaptivePortalFirewall.pm
+++ b/main/captiveportal/src/EBox/CaptivePortalFirewall.pm
@@ -207,4 +207,12 @@ sub _exceptionsRules
     return \@rules;
 }
 
+# we stop captiveportal to avoid race condition with not-yet added captive
+# portal rules
+sub beforeFwRestart
+{
+    my ($self) = @_;
+    $self->{captiveportal}->stopService();
+}
+
 1;

--- a/main/firewall/ChangeLog
+++ b/main/firewall/ChangeLog
@@ -1,6 +1,8 @@
 HEAD
+	+ Added beforeFwRestart method to firewall helper
 	+ Fixed crash when editing view in Summarized Report
 	+ Added EBox::Iptables::executeModuleRules to be able to execute
+	  rules from a given module calling this new method
 3.2.2
 	+ Removed code made dead by new managament of DHCP nameservers
 3.2.1

--- a/main/firewall/src/EBox/Firewall.pm
+++ b/main/firewall/src/EBox/Firewall.pm
@@ -185,6 +185,12 @@ sub _enforceServiceState
     use EBox::Iptables;
     my $ipt = new EBox::Iptables;
     if($self->isEnabled()) {
+        foreach my $mod (@{ $self->global()->modInstancesOfType('EBox::FirewallObserver') }) {
+            my $helper = $mod->firewallHelper();
+            if ($helper) {
+                $helper->beforeFwRestart();
+            }
+        }
         $ipt->start();
     } else {
         $ipt->stop();

--- a/main/firewall/src/EBox/FirewallHelper.pm
+++ b/main/firewall/src/EBox/FirewallHelper.pm
@@ -300,4 +300,15 @@ sub _inputIface # (iface)
     }
 }
 
+# Method: beforeFwRestart
+#
+#  called before the restart of the firewall when it is enabled
+#
+#  The default implementation does nothing
+#
+sub beforeFwRestart
+{
+}
+
+
 1;


### PR DESCRIPTION
The drawback of this is that the captie protal user could not navigate until the captiveprotal restarts
