### PR TITLE
Disable QA updates until next commercial edition

### DIFF
--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Disable QA updates until next commercial edition
 	+ DisasterRecoveryDomains can notify other models
 	+ Fix remove conf backup after PSGI migration
 	+ Fix overwrite action on remote conf backup

--- a/main/remoteservices/conf/remoteservices.conf
+++ b/main/remoteservices/conf/remoteservices.conf
@@ -29,13 +29,13 @@ rs_verify_servers = yes
 # If you change this value, you must run the following command:
 #  sudo /usr/share/zentyal-software/rewrite-conf
 # (Default: yes)
-qa_updates_exclusive_source = yes
+qa_updates_exclusive_source = no
 
 # If set to a 'yes' value if the Zentyal QA updates are used, they will
 # be automatic to ensure you have always a system updated from a
 # trusted source.
 # (Default: yes)
-qa_updates_always_automatic = yes
+qa_updates_always_automatic = no
 
 # If set to a 'yes' value, the monitoring stats will be sent using the VPN
 # This method is more secure, but tends to have service interruptions


### PR DESCRIPTION
An event was set up to enable them again in August.
