### PR TITLE
Allow network proxy which is listening on localhost

### DIFF
--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Allow network proxy which is listening on localhost
 3.2.6
 	+ Specifiy local address in failover tests to avoid vlan interface problems
 	+ Fix Dynamic DNS with Zentyal Remote as provider when the

--- a/main/network/src/EBox/Network/Model/Proxy.pm
+++ b/main/network/src/EBox/Network/Model/Proxy.pm
@@ -141,7 +141,7 @@ sub validateTypedRow
         if ($server) {
             my $netMod = $self->parentModule();
             my $iface = $netMod->ifaceByAddress($server);
-            if ($iface) {
+            if ($iface and ($iface ne 'lo')) {
                 throw EBox::Exceptions::External(
                     __x('Proxy {addr} is invalid because it is the address of the interface {if}',
                         addr => $server,


### PR DESCRIPTION
This scenario should be allowed to be able to interface better with external programs. For example a wan accelerator running in localhost
