### PR TITLE
Allow openchange to work with old ldb/tdb backends

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Allow openchange working with old ldb/tdb backends (upgrade from 3.3)
 3.4.1
 	+ Generate master password for IMAP access
 3.4

--- a/main/openchange/src/EBox/OpenChange.pm
+++ b/main/openchange/src/EBox/OpenChange.pm
@@ -1000,7 +1000,7 @@ sub isProvisionedWithMySQL
 {
     my ($self) = @_;
 
-    return $self->isProvisioned() and (-e OPENCHANGE_MYSQL_PASSWD_FILE);
+    return ($self->isProvisioned() and (-e OPENCHANGE_MYSQL_PASSWD_FILE));
 }
 
 # Method: connectionString


### PR DESCRIPTION
This is only needed when upgrading from Zentyal 3.3 to zentyal 3.4

We also need this on master
