### PR TITLE
Remove 'homes' from sambaHomePath ldap attribute.

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,8 @@
-HEAD
+2.2.1
+	+ Remove the 'homes' part from sambaHomePath ldap attribute. Fixes the
+	  wrong mount point for home drive when a folder with the same name as the
+	  user exists in its home.
+2.2
 	+ Restart apache on first enable to avoid missing model error in
 	  log observer event
 	+ Use always the same string to refer to the NetBIOS computer name

--- a/main/samba/src/EBox/SambaLdapUser.pm
+++ b/main/samba/src/EBox/SambaLdapUser.pm
@@ -78,7 +78,7 @@ sub new
 sub _smbHomes
 {
     my $samba = EBox::Global->modInstance('samba');
-    return "\\\\" . $samba->netbios() . "\\homes\\";
+    return "\\\\" . $samba->netbios() . "\\";
 }
 
 sub _smbProfiles
@@ -1123,7 +1123,7 @@ sub updateNetbiosName
         my $username = $entry->get_value('uid');
 
         $ldap->modifyAttribute($dn, 'sambaHomePath',
-                "\\\\$netbios\\homes\\$username");
+                "\\\\$netbios\\$username");
         # XXX Check if we have to add or not, instead of
         # add + [ delete ]
         $ldap->modifyAttribute($dn, 'sambaProfilePath',


### PR DESCRIPTION
It cause wrong mount point for home drive when a folder exists in the user
home with the same name as the user. The attribute is change from
\netbios\homes\user to \netbios\user.
