### PR TITLE
Removing TryCatch::Lite use, left there after backport

### DIFF
--- a/main/openchange/src/EBox/OpenChange/Model/Configuration.pm
+++ b/main/openchange/src/EBox/OpenChange/Model/Configuration.pm
@@ -30,8 +30,6 @@ use EBox::Types::Select;
 use EBox::Types::Text;
 use EBox::Types::Union;
 
-use TryCatch::Lite;
-
 # Method: new
 #
 #   Constructor, instantiate new model


### PR DESCRIPTION
First bug spotted thanks to the correct isolation of environments with Docker, right now the build it's broken for 3.2 in master after merge this, it will be fixed.
