### PR TITLE
Fixing problem with the version of the JSON-RPC lib in perl, using Legac...

### DIFF
--- a/extra/scripts/zentyal-syntax-check
+++ b/extra/scripts/zentyal-syntax-check
@@ -140,11 +140,7 @@ sub filter
         ($src =~ m{/EventDaemon\.pm$}) or
         ($src =~ m{/Logout/}) or
         ($src =~ m{/Notificate\.pm$}) or
-        ($src =~ m{/Certificates\.pm$}) or
-        ($src =~ m{/CrashReport\.pm$}) or
-        ($src =~ m{/CreateReport\.pm$}) or
-        ($src =~ m{/CGI/Log\.pm$}) or
-        ($src =~ m{/BugReport\.pm$})) {
+        ($src =~ m{/Certificates\.pm$})) {
         return 1;
     }
 

--- a/main/core/src/EBox/Util/BugReport.pm
+++ b/main/core/src/EBox/Util/BugReport.pm
@@ -20,7 +20,7 @@ package EBox::Util::BugReport;
 
 use EBox::Config;
 use EBox::Exceptions::Internal;
-use JSON::RPC::Client;
+use JSON::RPC::Legacy::Client;
 use MIME::Base64;
 use File::Slurp;
 use TryCatch::Lite;
@@ -54,7 +54,7 @@ sub send
     my $version = `dpkg -s zentyal-core|grep ^Version:`;
     ($version) =~ /^Version: (\d+\.\d+)/;
 
-    my $client = new JSON::RPC::Client;
+    my $client = new JSON::RPC::Legacy::Client;
 
     my $title = 'Bug report from Zentyal Server';
     my $callobj = {


### PR DESCRIPTION
...y version

The library JSON:RPC has done a change in the new version that it's not backwards compatible.

See section BACKWARDS COMPATIBILITY http://search.cpan.org/~dmaki/JSON-RPC-1.03/lib/JSON/RPC.pm
