### PR TITLE
Mjulian/sogo contacts get cn

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Make SOGo shared contacts display their CN
 3.2.8
 	+ Allow ActiveSync setup if z-push or sogo-activesync are installed
 	+ Updated SOGo conf

--- a/main/openchange/stubs/sogo.conf.mas
+++ b/main/openchange/stubs/sogo.conf.mas
@@ -102,6 +102,9 @@
             displayName = "Shared Contacts";
             id = sharedContacts;
             isAddressBook = YES;
+            mapping = {
+                displayname = ("cn");
+            };
             filter = "((((objectClass=inetOrgPerson) AND ((uidNumber>=2000) OR (mail=\'*\'))) AND (NOT internal=1) AND (NOT uid=Guest)) OR (((objectClass=zentyalDistributionGroup) AND (gidNumber>=2000)) AND (NOT internal=1)))";
         }
     );


### PR DESCRIPTION
Make SOGo shared contacts display their CN.

It will show a proper display name for the newer contacts, but not for the older ones. This "hack" will do that.
