### PR TITLE
Renamed a groupaliases.cf.mas parameter that was failing

### DIFF
--- a/main/mail/ChangeLog
+++ b/main/mail/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Fix groupaliases.cf parameter stub
 3.5
 	+ Adapt alias management to constraints by mailboxRelatedObject
 	+ Changed amavis submision service to avoid rewriting rules

--- a/main/mail/stubs/groupaliases.cf.mas
+++ b/main/mail/stubs/groupaliases.cf.mas
@@ -4,11 +4,8 @@
         $bindDN
         $bindPW
         $baseDN
-        $ldap
+        $ldapServer
 </%args>
-<%init>
-my $ldapServer = 'localhost:' . $ldap->{port};
-</%init>
 server_host = <% $ldapServer %>
 version = 3
 search_base = <% $baseDN %>


### PR DESCRIPTION
Renamed a groupaliases.cf.mas parameter that was failing
