### PR TITLE
Save changes is now properly done as a single redis transaction

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 3.5
+	+ Save changes is now properly done as a single redis transaction
 	+ Assure that all data under a row directory is removed
 	+ EBox::Types::DomainName always return lowercase values
 	+ EBox::Types::Host always return lowercase values

--- a/main/core/src/EBox/GlobalImpl.pm
+++ b/main/core/src/EBox/GlobalImpl.pm
@@ -533,10 +533,14 @@ sub _prepareActionScript
     my $script = EBox::Config::scripts() . 'global-action';
     $script .= " --action $action";
 
-    my $progressIndicator =  EBox::ProgressIndicator->create(
-            executable => $script,
-            totalTicks => $totalTicks,
-            );
+    my $progressIndicator = EBox::ProgressIndicator->create(
+        executable => $script,
+        totalTicks => $totalTicks,
+    );
+
+    # Flush current transaction so the process started by
+    # progress indicator can start its own one
+    $self->redis()->commit();
 
     $progressIndicator->runExecutable();
 

--- a/main/core/src/scripts/global-action
+++ b/main/core/src/scripts/global-action
@@ -32,14 +32,18 @@ if ($progressId) {
     @callParams = (progress => $progress);
 }
 
+my $global = EBox::Global->getInstance();
+my $redis = $global->redis();
 try {
-    my $global = EBox::Global->getInstance();
+    $redis->begin();
     if ($action eq 'saveAllModules') {
         $global->saveAllModules(@callParams);
     } elsif ($action eq 'revokeAllModules') {
         $global->revokeAllModules(@callParams);
     }
+    $redis->commit();
 } catch ($ex) {
+    $redis->rollback();
     if ($progress) {
         my $errorTxt = blessed($ex) ? $ex->text() : $ex;
         if (EBox::Config::boolean('debug') and blessed($ex)) {


### PR DESCRIPTION
this fixes some issues with the resolvconf hooks during the save changes of network, but it may break other things (although is the proper way of doing it), just doing the pull request to see if at least tests pass
