### PR TITLE
The groups and groupsNotIn methods have now the same behaviour  for all ...

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ The groups and groupsNotIn methods have now the same behaviour
+	  for all EBox::Samba::OrganizationalPerson classes
 	+ Catch error trying to add an already added or delete an already deleted
 	  user to group
 	+ Avoid warning flag on smart match experimental feature

--- a/main/samba/src/EBox/Samba/CGI/EditContact.pm
+++ b/main/samba/src/EBox/Samba/CGI/EditContact.pm
@@ -49,8 +49,8 @@ sub _process
     my $dn = $self->unsafeParam('dn');
     my $contact = new EBox::Samba::Contact(dn => $dn);
 
-    my $contactgroups = $contact->groups();
-    my $remaingroups = $contact->groupsNotIn();
+    my $contactgroups = $contact->groups(internal => 0, system => 1);
+    my $remaingroups = $contact->groupsNotIn(internal => 0, system => 1);
 
     my $editable = $usersMod->editableMode();
 

--- a/main/samba/src/EBox/Samba/OrganizationalPerson.pm
+++ b/main/samba/src/EBox/Samba/OrganizationalPerson.pm
@@ -197,12 +197,18 @@ sub _groups
         scope => 'sub',
     };
 
+
+
     my $result = $self->_ldap->search($attrs);
 
     my $groups = [];
     if ($result->count > 0) {
         foreach my $entry ($result->sorted('cn')) {
-            push (@{$groups}, new EBox::Samba::Group(entry => $entry));
+            my $group =  new EBox::Samba::Group(entry => $entry);
+            next if ($group->isInternal() and not $params{internal});
+            next if ($group->isSystem() and not $params{system});
+
+            push (@{$groups}, $group);
         }
     }
     return $groups;

--- a/main/samba/src/EBox/Samba/User.pm
+++ b/main/samba/src/EBox/Samba/User.pm
@@ -692,21 +692,6 @@ sub save
     }
 }
 
-sub _groups
-{
-    my ($self, %params) = @_;
-
-    my @groups = @{$self->SUPER::_groups(%params)};
-
-    my $filteredGroups = [];
-    for my $group (@groups) {
-        next if ($group->isInternal() and not $params{internal});
-        next if ($group->isSystem() and not $params{system});
-        push (@{$filteredGroups}, $group);
-    }
-    return $filteredGroups;
-}
-
 # Method: isSystem
 #
 #   Return 1 if this is a system user, 0 if not


### PR DESCRIPTION
...EBox::Samba::OrganizationalPerson classes

The different behaviour was detected in the edit contact page, it displayed all the internal groups
