### PR TITLE
Roundcube webmail uses again 127.0.0.1 as IMAP server

### DIFF
--- a/main/webmail/ChangeLog
+++ b/main/webmail/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Roundcube webmail uses again 127.0.0.1 as IMAP server
 3.5
 	+ Webmail depends on Zentyal Mail module
 	+ Set version to 3.5

--- a/main/webmail/src/EBox/WebMail.pm
+++ b/main/webmail/src/EBox/WebMail.pm
@@ -195,18 +195,14 @@ sub _confFromMail
     my $mail = EBox::Global->modInstance('mail');
     my @conf;
 
-    my $ip = $self->_getNonLocalhostIp();
-
-    # Do not change the imapServer to 127.0.0.1 nor localhost
-    # Users would do login with incorrect passwords
     if ($mail->imap()) {
         @conf = (
-                 imapServer => $ip,
+                 imapServer => '127.0.0.1',
                  imapPort   => 143,
                 );
     } elsif ($mail->imaps()) {
         @conf = (
-                 imapServer => 'ssl://' . $ip,
+                 imapServer => 'ssl://127.0.0.1',
                  imapPort => 993,
                 );
     } elsif ($self->isEnabled) {
@@ -219,26 +215,6 @@ sub _confFromMail
                 );
 
     return \@conf;
-}
-
-sub _getNonLocalhostIp
-{
-    my ($self) = @_;
-
-    my @allIPAddresses = ();
-    my $network = $self->global()->modInstance('network');
-
-    my $internalIPAddresses = $network->internalIpAddresses();
-    foreach my $ipaddress (@{$internalIPAddresses}) {
-        push (@allIPAddresses, $ipaddress);
-    }
-
-    my $externalIPAddresses = $network->externalIpAddresses();
-    foreach my $ipaddress (@{$externalIPAddresses}) {
-        push (@allIPAddresses, $ipaddress);
-    }
-
-    return (@allIPAddresses ? shift(@allIPAddresses) : '127.0.2.1');
 }
 
 sub _confForRemoteServer


### PR DESCRIPTION
This was changed due to a Openchange policy added to Dovecot that
allowed any user from localhost to login against the IMAP server
without a correct password (also Roundcube)
