### PR TITLE
Start captive portal after stopping it

### DIFF
--- a/main/captiveportal/ChangeLog
+++ b/main/captiveportal/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Stop/start captive portal on firewall restart
 3.2.4
 	+ Use a blocking lock to get iptables resource to avoid issues
 	  while firewall module is restarting

--- a/main/captiveportal/src/EBox/CaptivePortalFirewall.pm
+++ b/main/captiveportal/src/EBox/CaptivePortalFirewall.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2013 Zentyal S.L.
+# Copyright (C) 2011-2014 Zentyal S.L.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2, as
@@ -207,17 +207,47 @@ sub _exceptionsRules
     return \@rules;
 }
 
-# we stop captiveportal to avoid race condition with not-yet added captive
-# portal rules
+# Method: beforeFwRestart
+#
+#    Stop captiveportal to avoid race condition with not-yet added captive
+#    portal rules
+#
+# Overrides:
+#
+#    <EBox::FirewallHelper::beforeFwRestart>
+#
 sub beforeFwRestart
 {
     my ($self) = @_;
     if ($self->{captiveportal}->needsSaveAfterConfig()) {
-        # not really started and damoen file not configured, no need to stop
+        # not really started and daemon file not configured, no need to stop
         return;
     }
 
-    $self->{captiveportal}->stopService();
+    $self->{captiveportal}->_stopService();
+}
+
+# Method: afterFwRestart
+#
+#    Start captiveportal stopped by <beforeFWRestart> to avoid race
+#    condition with not-yet added captive portal rules
+#
+# Overrides:
+#
+#    <EBox::FirewallHelper::afterFwRestart>
+#
+sub afterFwRestart
+{
+    my ($self) = @_;
+
+    if ($self->{captiveportal}->needsSaveAfterConfig()) {
+        # not really started and daemon file not configured, no need
+        # to start it
+        return;
+    }
+
+    $self->{captiveportal}->_startService();
+
 }
 
 1;

--- a/main/firewall/ChangeLog
+++ b/main/firewall/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Added afterFwRestart method to firewall helper
 3.2.4
 	+ Use a blocking lock to get iptables resource on restart
 	  and stop to avoid other modules to get it

--- a/main/firewall/src/EBox/Firewall.pm
+++ b/main/firewall/src/EBox/Firewall.pm
@@ -193,6 +193,7 @@ sub _enforceServiceState
 
     EBox::Util::Lock::lock('iptables', 1, BLOCKED_TIMEOUT);
     try {
+        my @helpers = ();
         if ($self->isEnabled()) {
             foreach my $mod (@{ $self->global()->modInstancesOfType('EBox::FirewallObserver') }) {
                 if (not $mod->configured() and not $mod->isEnabled()) {
@@ -201,9 +202,13 @@ sub _enforceServiceState
                 my $helper = $mod->firewallHelper();
                 if ($helper) {
                     $helper->beforeFwRestart();
+                    push(@helpers, $helper);
                 }
             }
             $ipt->start();
+            foreach my $helper (@helpers) {
+                $helper->afterFwRestart();
+            }
         } else {
             $ipt->stop();
         }

--- a/main/firewall/src/EBox/FirewallHelper.pm
+++ b/main/firewall/src/EBox/FirewallHelper.pm
@@ -1,5 +1,5 @@
 # Copyright (C) 2004-2007 Warp Networks S.L.
-# Copyright (C) 2008-2013 Zentyal S.L.
+# Copyright (C) 2008-2014 Zentyal S.L.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2, as
@@ -302,11 +302,21 @@ sub _inputIface # (iface)
 
 # Method: beforeFwRestart
 #
-#  called before the restart of the firewall when it is enabled
+#  called before firewall module restart when it is enabled
 #
 #  The default implementation does nothing
 #
 sub beforeFwRestart
+{
+}
+
+# Method: afterFwRestart
+#
+#  Called after firewall module restart when it is enabled
+#
+#  The default implementation does nothing
+#
+sub afterFwRestart
 {
 }
 


### PR DESCRIPTION
This fixes a regression introduced by ee986d82 (#1227)

This is done by adding <afterFwRestart> method to firewall helpers
