### PR TITLE
Use .crt when downloading the certificate for RPC/Proxy

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Use .crt when downloading the certificate for RPC/Proxy
+	  to ease Windows importing
 3.5.3
 	+ Notify when OpenChange is using the domain certificate
 	+ Migrate RPC Proxy certificate to new use our zentyal-ca

--- a/main/openchange/src/EBox/Downloader/CGI/RPCCert.pm
+++ b/main/openchange/src/EBox/Downloader/CGI/RPCCert.pm
@@ -24,6 +24,8 @@ use EBox::Config;
 use EBox::Gettext;
 use EBox::Exceptions::External;
 
+use File::Basename;
+
 sub new
 {
     my ($class, %params) = @_;
@@ -62,6 +64,11 @@ sub _process
         throw EBox::Exceptions::External(__('Cannot get the CA certificate as it is not available'));
     }
     $self->SUPER::_process();
+    # Use .crt extension to ease Windows import
+    my ($filename, $directories, $suffix) = fileparse($self->{downfile}, qr/\.[^.]+$/);
+    if ($suffix ne 'crt') {
+        $self->{downfilename} = "${filename}.crt";
+    }
 }
 
 1;


### PR DESCRIPTION
To ease Windows import
