### PR TITLE
Enabling SOGo login with user mail address

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Enabling SOGo login with user mail address makes possible Z-Push
+	  carddav server synchronization
 3.5.4
 	+ Tune OCSManager configuration for autodiscover
 	+ Redirect all /ews/ requests to OCSManager

--- a/main/openchange/stubs/sogo.conf.mas
+++ b/main/openchange/stubs/sogo.conf.mas
@@ -81,14 +81,14 @@
             displayName = "SambaLogin";
             canAuthenticate = YES;
             type = ldap;
-            CNFieldName = cn;
-            IDFieldName = cn;
-            UIDFieldName = sAMAccountName;
+            CNFieldName = mail;
+            IDFieldName = mail;
+            UIDFieldName = mail;
             hostname = "<% $sambaHost %>";
             baseDN = "CN=Users,<% $sambaBaseDN %>";
             bindDN = "<% $sambaBindDN %>";
             bindPassword = "<% $sambaBindPwd %>";
-            bindFields = (sAMAccountName);
+            bindFields = (sAMAccountName, mail);
         },
         {
             id = sambaShared;


### PR DESCRIPTION
Z-push was having problems when trying to sync information from carddav sogo server. Allowing the users to login also with their mail address solves the problem of users using different mail address than their username, ie:
username: mjulian 
mail address: figarcorso@company.lte

To solve this issue, this PR should also be released: https://github.com/Zentyal/Z-Push-contrib/pull/2
