### PR TITLE
Fix subscription with several bundles but all of the same type

### DIFF
--- a/extra/installer/ChangeLog
+++ b/extra/installer/ChangeLog
@@ -1,4 +1,5 @@
 4.0
+    + Allow server subscriptions with several bundles but all of the same type
     + Set versions and repos to 4.0
 3.5
     + Use Server Password to get the conf backup list

--- a/extra/installer/zinstaller-remote/debian/postinst
+++ b/extra/installer/zinstaller-remote/debian/postinst
@@ -120,7 +120,7 @@ then
         exit 0
     elif [ $NUM_BUNDLES -eq 1 ]
     then
-        BUNDLE_ID=$(cut -d: -f1 $DATA_DIR/BUNDLE_IDS)
+        BUNDLE_ID=$(head -1 $DATA_DIR/BUNDLE_IDS | cut -d: -f1)
         if grep "Premium" $DATA_DIR/BUNDLE_IDS
         then
             db_input high zinstaller-remote/auth_ok_premium


### PR DESCRIPTION
I get a `$BUNDLE_IDS` file with the following content:

```
9585:"COMPANYNAME - Premium Edition" 
9586:"COMPANYNAME - Premium Edition" 
9587:"COMPANYNAME - Premium Edition" 
9588:"COMPANYNAME - Premium Edition" 
```

This will be considered as having 1 bundle and the script will set badly the `$BUNDLE_ID` variable that will be used in following https requests (that will fail with a 400 error: bad request)

The problem is that `$BUNDLE_ID` will be set (with the previous `$BUNDLE_IDS` example file) to `9585 9586 9587 9588` we want to be set with any of those ids (only one).

:exclamation: This need to be merged also into **3.2** branch :exclamation: 
