### PR TITLE
Fix pageReload function for urls with hash

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 4.0
+	+ Reload after save changes when urls have hash part
 	+ Default webadmin port is now 8443
 	+ Remove haproxy which is no longer needed for Outlook Anywhere
 	+ UI is now responsive to different resolutions

--- a/main/core/www/js/common.js
+++ b/main/core/www/js/common.js
@@ -48,6 +48,8 @@ Zentyal.pageReload = function() {
     var url,
     urlParts = window.location.href.split('?');
     url = urlParts[0];
+    // Remove hash part, otherwise it won't reload
+    url = url.replace(window.location.hash, "");
     if (urlParts.length >= 2) {
         var i,
         params,


### PR DESCRIPTION
Steps to reproduce it:
- Go to DNS section and add one forwarder (url now will be like `https://192.168.6.4:8443/DNS/Composite/Global#Forwarder`)
- Save changes
- Wait... Click Ok
- No reload, still save changes button present

The problem is that you won't reload a page with urls with '#foo' part. For instance, try 

```
window.location = window.location.url + '#Foo'
```

vs

```
window.location = window.location.url
```
