### PR TITLE
Use separate apache log files for ocsmanager

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,4 +1,5 @@
 4.0
+	+ Use separate apache log files for ocsmanager
 	+ Allow to customize CA attributes on initial configuration wizard
 	+ RPC proxy is available in web interface when you have only
 	  internal interfaces

--- a/main/openchange/stubs/apache-ocsmanager.conf.mas
+++ b/main/openchange/stubs/apache-ocsmanager.conf.mas
@@ -16,4 +16,7 @@
 
     # ocsmanager Exchange Web Services (ews)
     ProxyPass /ews http://127.0.0.1:5000/ews
+
+    CustomLog ${APACHE_LOG_DIR}/ocsmanager-access.log combined
+    ErrorLog ${APACHE_LOG_DIR}/ocsmanager-error.log
 </VirtualHost>


### PR DESCRIPTION
I see useful to have different log files for ocsmanger, otherwise the log is dumped to the other_vhost log files. 

Of course we can change the path to other directory but I think that 'apache' is the more appropriate
