### PR TITLE
Fix remote manual backup

### DIFF
--- a/main/core/src/EBox/RemoteServices/Backup.pm
+++ b/main/core/src/EBox/RemoteServices/Backup.pm
@@ -54,9 +54,9 @@ sub prepareMakeRemoteBackup
     $label or throw EBox::Exceptions::MissingArgument('label');
 
     my @backupOptions = (
-        description => $label,
-        remoteBackup => $label,
-       );
+        description  => $label,
+        remoteBackup => 1,
+    );
 
     return EBox::Backup->prepareMakeBackup(@backupOptions);
 }
@@ -108,7 +108,7 @@ sub makeRemoteBackup
 #      description - String the backup's description
 #
 #      automatic - Boolean indicating whether the backup must be set as
-#                  automatic or not
+#                  automatic or not. Optional. Default value: false
 #
 # Exceptions:
 #

--- a/main/core/src/scripts/make-backup
+++ b/main/core/src/scripts/make-backup
@@ -103,7 +103,7 @@ try {
             eval 'use EBox::RemoteServices::Backup';
             my $backupService = EBox::RemoteServices::Backup->new();
             my $description = $params{description};
-            $backupService->sendRemoteBackup($file, $remoteBackupName, $description);
+            $backupService->sendRemoteBackup($file, $description);
 
             if ($progress) {
                 $progress->setAsFinished();


### PR DESCRIPTION
The remote backup name is not longer used.

All manual backups are now manual.
