### PR TITLE
Do not send modifyUser notification to slaves on creation

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Avoid notifying slaves while setting the password as it is does
+	  by addUser called below
 	+ Fix regression in showing the Administrator account
 4.0.1
 	+ A change in first or last name make DN to change

--- a/main/samba/src/EBox/Samba/User.pm
+++ b/main/samba/src/EBox/Samba/User.pm
@@ -426,7 +426,7 @@ sub setFullName
 #       kerberosKeys - Set of kerberos keys
 #       isSystemUser - boolean: if true it adds the user as system user, otherwise as normal user
 #       uidNumber - user UID number
-#       ignoreSlaves - Boolean to avoid notifying LDAP slaves
+#       ignoreSlaves - Array ref with the LDAP slaves to ignore while notifying
 #
 # Returns:
 #
@@ -544,7 +544,9 @@ sub create
 
         $res = new EBox::Samba::User(dn => $dn);
 
-        # Set the password
+        # Set the password with no notifying the slaves as addUser will do
+        my @allSlavesNames = map { $_->name() } @{$usersMod->allSlaves()};
+        $res->{ignoreSlaves} = \@allSlavesNames;
         if (defined $args{password}) {
             $res->changePassword($args{password});
             $res->setAccountEnabled(1);
@@ -552,6 +554,7 @@ sub create
             $res->setCredentials($args{kerberosKeys});
             $res->setAccountEnabled(1);
         }
+        $res->{ignoreSlaves} = undef;
 
         if ($args{ignoreSlaves}) {
             $res->{ignoreSlaves} = $args{ignoreSlaves};


### PR DESCRIPTION
- Avoid notifying slaves while setting the password as it is does
  by addUser called below
