### PR TITLE
zentyal-sogo package removal management

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ zentyal-sogo package removal management
 4.0.1
 	+ Cache DomainTable DNS model in VDomains to avoid querying it in
 	  acquirers

--- a/main/openchange/debian/control
+++ b/main/openchange/debian/control
@@ -18,6 +18,7 @@ Depends: zentyal-core (>= 4.0), zentyal-core (<< 4.1),
          apache2, zoctools, zip, rabbitmq-server,
          sogo-openchange (>= 2.2.5-zentyal1~20140618-1~108),
          ${misc:Depends}
+Replaces: zentyal-sogo
 Description: Zentyal - OpenChange Server
  Zentyal is a Linux small business server that can act as
  a Gateway, Unified Threat Manager, Office Server, Infrastructure
@@ -26,3 +27,9 @@ Description: Zentyal - OpenChange Server
  .
  This module provides a complete solution to interoperate with Microsoft
  Outlook clients or Microsoft Exchange servers.
+
+Package: zentyal-sogo
+Depends: zentyal-openchange, ${misc:Depends}
+Architecture: all
+Description: transitional dummy package
+  This is a transitional dummy package. It can safely be removed.


### PR DESCRIPTION
Created a transitional zentyal-sogo package to avoid dependencies 'autoremove' while upgrading.
