### PR TITLE
 Fix not defined domain in log's ConfigureLogs model

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fix not defined domain in log's ConfigureLogs model
 	+ Modify webadmin service when upgrading from 3.2
 	+ Show enable errors in module status table
 4.0.2

--- a/main/core/src/EBox/Logs/Model/ConfigureLogs.pm
+++ b/main/core/src/EBox/Logs/Model/ConfigureLogs.pm
@@ -112,7 +112,12 @@ sub syncRows
     my %storedLogDomains;
     foreach my $id (@{$currentRows}) {
         my $row = $self->row($id);
-        $storedLogDomains{$row->valueByName('domain')} = 1;
+        my $domain = $row->valueByName('domain');
+        if (not $domain) {
+            EBox::warn("ConfigureLogs row $id has not domain element");
+            next;
+        }
+        $storedLogDomains{$domain} = 1;
     }
 
     # Fetch the current available log domains


### PR DESCRIPTION
This is a tentative fix for a unreproducible for me error. The error exists as has been reported for several persons like this one, https://tracker.zentyal.org/issues/2644

It does not fix the root problem, but it should mitigate it and it uses a log warning to not hid it.
