### PR TITLE
Set RPC Proxy log level to debug only when debug is enabled

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Set RPC Proxy log level to debug only when debug is enabled
 	+ ActiveSync needs to have a HTTPS webmail enabled. Also handling
 	  Z-Push config files
 	+ Updated vdomains model strings warning about HTTP usage

--- a/main/openchange/src/EBox/OpenChange.pm
+++ b/main/openchange/src/EBox/OpenChange.pm
@@ -655,6 +655,7 @@ sub _setOCSManagerConf
                 push (@{$params}, rpcproxy => $rpcProxyHttp);
                 push (@{$params}, rpcproxyAuthCacheDir => RPCPROXY_AUTH_CACHE_DIR);
                 push (@{$params}, webmail => $webmailHttp);
+                push (@{$params}, debug => EBox::Config::boolean('debug'));
 
                 my $conf = "${fid}-zentyal-ocsmanager-${domain}";
                 my $file = "/etc/apache2/conf-available/$conf.conf";

--- a/main/openchange/stubs/apache-ocsmanager.conf.mas
+++ b/main/openchange/stubs/apache-ocsmanager.conf.mas
@@ -26,6 +26,7 @@ Parameters:
     $rpcproxy
     $rpcproxyAuthCacheDir
     $webmail
+    $debug => 0
 </%args>
 
 user  <% $user %>
@@ -75,7 +76,7 @@ WSGIScriptAlias /rpcwithcert/rpcproxy.dll /usr/lib/openchange/web/rpcproxy/rpcpr
     Include /etc/apache2/mods-available/env.load
 
     <Directory /usr/lib/openchange/web/rpcproxy/>
-        SetEnv RPCPROXY_LOGLEVEL DEBUG
+        SetEnv RPCPROXY_LOGLEVEL <% $debug ? 'DEBUG' : 'INFO' %>
         SetEnv NTLMAUTHHANDLER_WORKDIR <% $rpcproxyAuthCacheDir %>
         SetEnv SAMBA_HOST 127.0.0.1
         WSGIPassAuthorization On


### PR DESCRIPTION
Debug makes things go slow and only useful for development
