### PR TITLE
Added disable_uid_sync conf key to save resources when RSAT or ADC mode ...

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ Added disable_uid_sync conf key to save resources when RSAT
+	  or ADC mode is not used
 	+ Migrate mailboxes when upgrading from Zentyal 3.2
 4.0.4
 	+ SysvolSync daemon now synchronize deleted GPOs.

--- a/main/samba/conf/samba.conf
+++ b/main/samba/conf/samba.conf
@@ -107,16 +107,12 @@ show_site_box = no
 # if you want to disable full audit, then uncomment next option
 #disable_fullaudit = yes
 
-# This is a temporary workaround for these Samba 4 bugs:
-#
-#   https://bugzilla.samba.org/show_bug.cgi?id=9866
-#   https://bugzilla.samba.org/show_bug.cgi?id=9867
-#
-# Uncomment this if you have guest shares enabled and want to join
-# Windows Vista computers to the domain. Please note that completely
-# anonymous share access will not work if you don't provide any valid
-# domain credentials, but at least you will be able to join.
-#join_vista_with_guest_shares = yes
+# Disable uid/gid sync daemon
+# Allowed values = [yes|no]
+# Default value = no
+# if you are not using RSAT or ADC modes, you can uncomment this in
+# order to save some resources
+#disable_uid_sync = yes
 
 # Uncomment this if you want to skip setting the home directory of the
 # users while saving changes

--- a/main/samba/src/EBox/Samba.pm
+++ b/main/samba/src/EBox/Samba.pm
@@ -1397,10 +1397,6 @@ sub _daemons
         return ($self->mode() eq STANDALONE_MODE);
     };
 
-    my $enabledAndProvisioned = sub {
-        return ($self->isEnabled() and $self->isProvisioned());
-    };
-
     return [
         {
             name => 'samba-ad-dc',
@@ -1420,9 +1416,18 @@ sub _daemons
         },
         {
             name => 'zentyal.set-uid-gid-numbers',
-            precondition => $enabledAndProvisioned,
+            precondition => \&_uidSyncEnabled,
         },
     ];
+}
+
+sub _uidSyncEnabled
+{
+    my ($self) = @_;
+
+    return 0 if EBox::Config::boolean('disable_uid_sync');
+
+    return ($self->isEnabled() and $self->isProvisioned());
 }
 
 # Method: _daemonsToDisable


### PR DESCRIPTION
...is not used

and remove reference to no longer existent option in samba.conf
