### PR TITLE
Fix error when removing the sogo database in deprovision

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fix error when removing the sogo database in deprovision
 	+ Improve config for Sogo, setting up WOWorkersCount to 3 from 1
 	+ Fixed unsaved changes precondition
 	+ Add Ubuntu standard document root to apache virtual servers

--- a/main/openchange/src/EBox/OpenChange.pm
+++ b/main/openchange/src/EBox/OpenChange.pm
@@ -1225,7 +1225,7 @@ sub dropSOGODB
 
     # Drop SOGo database and db user. To avoid error if it does not exists,
     # the user is created and granted harmless privileges before drop it
-    my $sogoDB = $self->_sogoDBengine();
+    my $sogoDB = $self->_sogoDBEngine();
     my $dbName = $sogoDB->_dbname();
     my $dbUser = $sogoDB->_dbuser();
 


### PR DESCRIPTION
Seen in the zentyal.log of this reported error https://tracker.zentyal.org/issues/2770