### PR TITLE
Change configuration in dovecot to make work shared folders in SOGo

### DIFF
--- a/main/mail/ChangeLog
+++ b/main/mail/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Change separator in dovecot to make work shared folders in SOGo
 	+ Fixing mail forwarding loop error with some isp's and fetchmail
 	+ Update OpenChange proxyAddresses attribute when setting mail account
 	+ In restore postpone recreation of mail directories until next

--- a/main/mail/debian/control
+++ b/main/mail/debian/control
@@ -8,7 +8,8 @@ Standards-Version: 3.9.2
 Package: zentyal-mail
 Architecture: all
 Pre-Depends: zentyal-core
-Depends: zentyal-core (>= 4.0), zentyal-core (<< 4.1), zentyal-firewall, zentyal-openchange,
+Depends: zentyal-core (>= 4.0), zentyal-core (<< 4.1),
+         zentyal-firewall, zentyal-openchange (>> 4.0.7),
          postfix, postfix-ldap, postfix-pcre, ssl-cert, libsasl2-modules, dovecot-common,
          dovecot-imapd, dovecot-pop3d, dovecot-sieve, dovecot-managesieved, dovecot-ldap,
          dovecot-gssapi, dovecot-sqlite, postgrey, fetchmail, archivemail, libcrypt-rijndael-perl,

--- a/main/mail/stubs/dovecot.conf.mas
+++ b/main/mail/stubs/dovecot.conf.mas
@@ -124,6 +124,7 @@ mail_gid=<% $gid %>
 
 namespace inbox {
     inbox=yes
+    separator = /
 
     mailbox Trash {
         auto = subscribe
@@ -149,6 +150,17 @@ namespace inbox {
         auto = create
         special_use = \Junk
     }
+
+    subscriptions = yes
+}
+
+namespace {
+    type = shared
+    separator = /
+    prefix = shared/%%u/
+    location = maildir:/var/vmail/%%d/%%n/Maildir:INDEXPVT=~/Maildir/shared/%%u
+    subscriptions = yes
+    list = children
 }
 
 ##
@@ -216,7 +228,7 @@ protocol lda {
 % if ($openchangePlugin->{enabled}) {
 %   $ldaPlugins = "notify openchange " . $ldaPlugins;
 % }
-  mail_plugins = <% $ldaPlugins %>
+  mail_plugins = <% $ldaPlugins %> acl
 }
 
 ##
@@ -283,9 +295,18 @@ service imap {
 }
 
 protocol imap {
-  mail_plugins = <% "@imapPlugins" %>
+  mail_plugins = <% "@imapPlugins" %> acl imap_acl
   mail_max_userip_connections = 20
 }
+
+plugin {
+    acl = vfile
+}
+
+plugin {
+    acl_shared_dict = file:/var/vmail/%d/shared-mailboxes.db
+}
+
 </%def>
 
 

--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Change separator to match the one in dovecot config
 	+ Check if provision is possible before saving changes
 4.0.7
 	+ Changes to allow provision as ADC

--- a/main/openchange/debian/control
+++ b/main/openchange/debian/control
@@ -9,8 +9,8 @@ Package: zentyal-openchange
 Architecture: all
 Pre-Depends: zentyal-core
 Depends: zentyal-core (>= 4.0), zentyal-core (<< 4.1),
-         zentyal-samba (>= 4.0.4), zentyal-mail, zentyal-ca (>= 4.0.1),
-         zentyal-dns (>= 4.0.1),
+         zentyal-samba (>= 4.0.4), zentyal-mail (>> 4.0.2),
+         zentyal-ca (>= 4.0.1), zentyal-dns (>= 4.0.1),
          openchangeserver (>= 3:2.3-zentyal7),
          openchange-rpcproxy, libstring-random-perl,
          openchange-ocsmanager (>> 3:2.3-zentyal1),

--- a/main/openchange/stubs/sogo.conf.mas
+++ b/main/openchange/stubs/sogo.conf.mas
@@ -55,7 +55,7 @@
     SOGoForceExternalLoginWithEmail = YES;
 
     /* IMAP server configuration */
-    NGImap4ConnectionStringSeparator = ".";
+    NGImap4ConnectionStringSeparator = "/";
     SOGoIMAPAclConformsToIMAPExt = NO;
     SOGoMailSpoolPath = /var/spool/sogo;
     SOGoIMAPServer = <% $imapServer %>;


### PR DESCRIPTION
Thanks to  googley in Zentyal forum

https://forum.zentyal.org/index.php/topic,24245.0/topicseen.html

This is a possible fix for the shared calendar sogo side. 

It need more review and testing before merging, we need to check sieve because I'm undoing this https://github.com/Zentyal/zentyal/commit/a5aae5b5a942cde4071bd247b80b2fcd79f9878f in here and can break other things.