### PR TITLE
Fixed sort order of EBox::Samba::users method

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Fixed sort order of EBox::Samba::users method
 	+ Increased default max log size to 100 MB
 	+ Backup and restore module's kerberos service password file
 4.0.5


### PR DESCRIPTION
Also in obth users and group method sort the user and groups objects after filtering them
instead of sorting previously the ldap entries