### PR TITLE
Allow restore samba from backup when it is not provisioned

### DIFF
--- a/main/mail/ChangeLog
+++ b/main/mail/ChangeLog
@@ -1,4 +1,6 @@
 HEAD
+	+ In restore postpone recreation of mail directories until next
+	  save change
 	+ Fix log helper exception trying to retrieve vdomains from LDAP when
 	  samba module is disabled
 4.0.2

--- a/main/mail/src/EBox/Mail.pm
+++ b/main/mail/src/EBox/Mail.pm
@@ -1555,6 +1555,13 @@ sub _preSetConf
 {
     my ($self) = @_;
 
+    my $state = $self->get_state();
+    my $recreateMaildirs = delete $state->{recreate_maildirs};
+    if ($recreateMaildirs) {
+        $self->_recreateMaildirs();
+        $self->set_state($state);
+    }
+
     return unless $self->configured();
 
     if ($self->service) {
@@ -1919,8 +1926,16 @@ sub dumpConfig
 sub restoreConfig
 {
     my ($self, $dir) = @_;
+    my $state = $self->get_state();
+    $state->{recreate_maildirs} = 1;
+    $self->set_state($state);
 
-    # recreate maildirs for accounts if needed
+    $self->{fetchmail}->restoreConfig($dir);
+}
+
+sub _recreateMaildirs
+{
+    my ($self) = @_;
     my @vdomains = $self->{vdomains}->vdomains();
     foreach my $vdomain (@vdomains) {
         my @addresses =
@@ -1933,8 +1948,6 @@ sub restoreConfig
             }
         }
     }
-
-    $self->{fetchmail}->restoreConfig($dir);
 }
 
 # Method: certificates

--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Allow restore backup when samba is not provisioned
 	+ Remove deprecated sids-to-hide file and associated methods
 	+ Fixed sort order of EBox::Samba::users method
 	+ Adapted migration code from 3.2 to 4.0

--- a/main/samba/src/EBox/Samba.pm
+++ b/main/samba/src/EBox/Samba.pm
@@ -2797,12 +2797,7 @@ sub restoreConfig
     if ($provisioned) {
         $self->_startService();
         $self->getProvision()->resetSysvolACL();
-    } else {
-        # my $dns = $self->global()->modInstance('dns');
-        # $dns->save();
-        # $dns->restartService();
-        # $dns->setAsChanged(1);
-    }
+    } 
 }
 
 sub _provisionFromBackup

--- a/main/samba/src/EBox/Samba.pm
+++ b/main/samba/src/EBox/Samba.pm
@@ -2669,7 +2669,7 @@ sub restoreBackupPreCheck
     if ($mode ne $backupMode) {
         my $modeModel = $self->model('Mode');
         throw EBox::Exceptions::External(
-            __x('Cannot restore users module bacuse is running in mode {mode} and the backup was made in mode {bpMode}',
+            __x('Cannot restore users module because is running in mode {mode} and the backup was made in mode {bpMode}',
                 mode => $modeModel->modePrintableName($mode),
                 bpMode => $modeModel->modePrintableName($backupMode),
                )
@@ -2718,8 +2718,19 @@ sub restoreBackupPreCheck
 sub restoreConfig
 {
     my ($self, $dir) = @_;
-    my $mode = $self->mode();
+    my $provisioned = $self->isProvisioned();
+    if (not $provisioned) {
+        try {
+            $self->getProvision()->checkEnvironment(1);
+        } catch ($ex) {
+            my $exError = "$ex";
+            my $error = __x("We cannot recreate the samba provision with the data from the backup because we get this error:\n{ex}",
+                           ex => $exError);
+            throw EBox::Exceptions::External($error);
+        }
+    }
 
+    my $mode = $self->mode();
     File::Slurp::write_file($dir . '/' . BACKUP_MODE_FILE, $mode);
     if ($mode ne STANDALONE_MODE) {
         # only standalone mode needs to do this operations to restore the LDAP
@@ -2737,7 +2748,9 @@ sub restoreConfig
         return;
     }
 
-    $self->stopService();
+    if ($provisioned) {
+        $self->stopService();
+    }
 
     # Remove private and sysvol
     my $privateDir = PRIVATE_DIR;
@@ -2781,9 +2794,24 @@ sub restoreConfig
     # Set provisioned flag
     $self->getProvision->setProvisioned(1);
 
-    $self->_startService();
+    if ($provisioned) {
+        $self->_startService();
+        $self->getProvision()->resetSysvolACL();
+    } else {
+        # my $dns = $self->global()->modInstance('dns');
+        # $dns->save();
+        # $dns->restartService();
+        # $dns->setAsChanged(1);
+    }
+}
 
-    $self->getProvision()->resetSysvolACL();
+sub _provisionFromBackup
+{
+    my ($self, $dir) = @_;
+    EBox::info("Provision samba before restoring backup");
+    my $provision = $self->getProvision();
+    $provision->checkEnvironment(1);
+    $provision->setProvisioned(1);
 }
 
 sub _removePasswds

--- a/main/samba/src/EBox/Samba/Provision.pm
+++ b/main/samba/src/EBox/Samba/Provision.pm
@@ -124,7 +124,7 @@ sub checkEnvironment
     my $domainNetbiosName = $settings->value('workgroup');
     my $hostNetbiosName = $settings->value('netbiosName');
     if (uc ($domainNetbiosName) eq uc ($hostNetbiosName)) {
-    $users->enableService(0);
+        $users->enableService(0);
         my $err = __x("The host netbios name '{x}' has to be the different " .
                       "than the domain netbios name '{y}'",
                       x => $hostNetbiosName, y => $domainNetbiosName);


### PR DESCRIPTION
Also a fix in the mail module to allow recreate maildir seven when LDAP is down in the restore. This is the case in the restore from unprovisioned.