### PR TITLE
Create roaming profile directory correctly when the samAccountName has a...

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Create roaming profile directory correctly when the
+	  samAccountName has any space
 4.0.7
 	+ Added config keys to enable samba to listen only on internal
 	  interfaces

--- a/main/samba/src/EBox/Samba/User.pm
+++ b/main/samba/src/EBox/Samba/User.pm
@@ -328,7 +328,7 @@ sub createRoamingProfileDirectory
     push (@perms, 'u:root:rwx');
     push (@perms, 'g::---');
     push (@perms, "g:$gidNumber:---");
-    push (@perms, "u:$samAccountName:rwx");
+    push (@perms, "u:'$samAccountName':rwx");
     push (@cmds, "setfacl -b \'$path\'");
     push (@cmds, 'setfacl -R -m ' . join(',', @perms) . " \'$path\'");
     push (@cmds, 'setfacl -R -m d:' . join(',d:', @perms) ." \'$path\'");


### PR DESCRIPTION
...ny space