### PR TITLE
We need to invert single/double commas in winbind command.

### DIFF
--- a/main/l2tp/ChangeLog
+++ b/main/l2tp/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Fixed single/double quote precedence
 4.0.1
 	+ Fixed samba dependency and related preconditions
 4.0

--- a/main/l2tp/stubs/options.xl2tpd.mas
+++ b/main/l2tp/stubs/options.xl2tpd.mas
@@ -28,5 +28,5 @@ connect-delay 5000
 %   if ($group) {
 require-mschap-v2
 plugin winbind.so
-ntlm_auth-helper '/usr/bin/ntlm_auth --helper-protocol=ntlm-server-1 --require-membership-of="<% $group %>"'
+ntlm_auth-helper "/usr/bin/ntlm_auth --helper-protocol=ntlm-server-1 --require-membership-of='<% $group %>'"
 %   }


### PR DESCRIPTION
Otherwise, we will get a log like this:

xl2tpd[691]: setsockopt recvref[30]: Protocol not available
xl2tpd[691]: Using l2tp kernel support.
xl2tpd[691]: xl2tpd version xl2tpd-1.3.6 started on myhostname PID:691
xl2tpd[691]: Written by Mark Spencer, Copyright (C) 1998, Adtran, Inc.
xl2tpd[691]: Forked by Scott Balmos and David Stipp, (C) 2001
xl2tpd[691]: Inherited by Jeff McAdams, (C) 2002
xl2tpd[691]: Forked again by Xelerance (www.xelerance.com) (C) 2006
xl2tpd[691]: Listening on IP address 4.5.6.7, port 1701
xl2tpd[691]: Connection established to 4.5.6.7, 1701.  Local: 3243, Remote: 11 (ref=0/0).  LNS session is 'default'
xl2tpd[691]: check_control: Received out of order control packet on tunnel 11 (got 3, expected 2)
xl2tpd[691]: handle_packet: bad control packet!
xl2tpd[691]: result_code_avp: result code not appropriate for Incoming-Call-Request.  Ignoring.
xl2tpd[691]: start_pppd: I'm running:
xl2tpd[691]: "/usr/sbin/pppd"
xl2tpd[691]: "passive"
xl2tpd[691]: "nodetach"
xl2tpd[691]: "10.1.20.19:10.1.20.20"
xl2tpd[691]: "refuse-pap"
xl2tpd[691]: "refuse-chap"
xl2tpd[691]: "auth"
xl2tpd[691]: "debug"
xl2tpd[691]: "file"
xl2tpd[691]: "/etc/ppp/zentyal-xl2tpd.my_vpn.options"
xl2tpd[691]: "plugin"
xl2tpd[691]: "pppol2tp.so"
xl2tpd[691]: "pppol2tp"
xl2tpd[691]: "7"
xl2tpd[691]: "pppol2tp_lns_mode"
xl2tpd[691]: "pppol2tp_tunnel_id"
xl2tpd[691]: "3243"
xl2tpd[691]: "pppol2tp_session_id"
xl2tpd[691]: "29562"
xl2tpd[691]: Call established with 1.2.3.4, Local: 29562, Remote: 1, Serial: 0
sh: 1: Syntax error: Unterminated quoted string