### PR TITLE
Dovecot quota based on LDAP

### DIFF
--- a/main/mail/stubs/dovecot-ldap.conf.mas
+++ b/main/mail/stubs/dovecot-ldap.conf.mas
@@ -19,5 +19,5 @@ auth_bind = yes
 
 user_filter = (&(mail=%u)(objectClass=user)(!(userAccountControl=514)))
 pass_filter = (&(mail=%u)(objectClass=user)(!(userAccountControl=514)))
-user_attrs = =home=/var/vmail/%Ld/%Ln/,=mail=maildir:/var/vmail/%Ld/%Ln/Maildir/
+user_attrs = =home=/var/vmail/%Ld/%Ln/,=mail=maildir:/var/vmail/%Ld/%Ln/Maildir/,=quota_rule=*:storage=%{ldap:mailquota}MB
 pass_attrs = mail=user

--- a/main/mail/stubs/dovecot.conf.mas
+++ b/main/mail/stubs/dovecot.conf.mas
@@ -243,7 +243,7 @@ dict {
 ## Plugin settings
 ##
 plugin {
-  quota = maildir:User quota
+  quota = maildir
   quota_rule = *:storage=0
 
   sieve = <% $mailboxesDir %>/%Ld/%Ln/sieve-script


### PR DESCRIPTION
With this fix, dovecot retrieves quota informations in the LDAP directory