### PR TITLE
Add execution of freshclam after enable antivirus

### DIFF
--- a/main/antivirus/ChangeLog
+++ b/main/antivirus/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Fix start of clamd that could take up to one hour to start working
 4.0.1
 	+ Force samba conf rewrite and restart in purge-module if AV is enabled
 4.0

--- a/main/antivirus/src/EBox/AntiVirus.pm
+++ b/main/antivirus/src/EBox/AntiVirus.pm
@@ -218,6 +218,22 @@ sub localSocket
     return CLAMD_SOCKET;
 }
 
+# Method: _postSetConfHook
+#
+# Overrides:
+#
+#      <EBox::Module::Base::_postSetConfHook>
+#
+sub _postSetConfHook
+{
+    my ($self) = @_;
+
+    # Run Freshclam first time so it works right away
+    EBox::Sudo::silentRoot("/usr/bin/freshclam --quiet");
+
+    $self->SUPER::_postSetConfHook();
+}
+
 # Method: _setConf
 #
 # Overrides:
@@ -258,7 +274,6 @@ sub _setConf
     $self->writeConfFile(FRESHCLAM_CRON_FILE,
                          'antivirus/clamav-freshclam.cron.mas',
                          [ enabled => $self->isEnabled() ]);
-
 }
 
 # Method: freshclamState

--- a/main/antivirus/stubs/freshclam.profile.mas
+++ b/main/antivirus/stubs/freshclam.profile.mas
@@ -2,6 +2,7 @@
   $observerScript
 </%args>
 /run/clamav/clamd.ctl rw,
+/proc/*/status r,
 # Run observer script
 /bin/dash ix,
 <% $observerScript %> rUx,


### PR DESCRIPTION
The cron could take up to one hour to execute the
antivirus update and make fail antivirus till then