### PR TITLE
Disable Vacations feature from SOGo webmail

### DIFF
--- a/main/openchange/ChangeLog
+++ b/main/openchange/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Disable Vacations feature from SOGo webmail
 	+ Disable SOGo login for user accounts without mail enabled
 	+ Enable password change from the SOGo webmail
 	+ Configure automatic refresh of SOGo webmail to 5 min

--- a/main/openchange/stubs/sogo.conf.mas
+++ b/main/openchange/stubs/sogo.conf.mas
@@ -70,7 +70,7 @@
     SOGoSMTPServer = <% $smtpServer %>;
 
     /* Sieve configuration */
-    SOGoVacationEnabled = YES;
+    SOGoVacationEnabled = NO;
     SOGoSieveScriptsEnabled = YES;
     SOGoForwardEnabled = YES;
 


### PR DESCRIPTION
Two reasons for this. One the automatic disable doesn't work
with actual configuration without enabling a cron, follow this
http://www.sogo.nu/bugs/view.php?id=1530

Second one is that this feature if used overrides all the functionality
implemented in OpenChange side for Out Of Office, so better get
rid of it for now till we make them understand each other better.