### PR TITLE
Harcoded group to keytab on External AD Mode

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Harcoded proxy group for keytab on External Ad Mode
 4.0.9
 	+ Added support for quotas on extra FS 
 4.0.8

--- a/main/samba/src/EBox/LDAP/ExternalAD.pm
+++ b/main/samba/src/EBox/LDAP/ExternalAD.pm
@@ -519,7 +519,7 @@ sub initKeyTabs
             my $path        = $ktab->{path};
             my $keytabFound = EBox::Sudo::fileTest('-r', $path);
             # external keytab must be owned by ebox but accessibe by the service user. We assume that the user has a group with the same name
-            my $keytabUser  = 'ebox'; 
+            my $keytabUser  = 'ebox';
             my $keytabGroup = $ktab->{user};
             my $service     = $ktab->{service};
             my $keytabTempPath = EBox::Config::tmp() . "$service.keytab";
@@ -551,7 +551,7 @@ sub initKeyTabs
 
             # Move keytab to the correct place
             EBox::Sudo::root("mv '$keytabTempPath' '$path'");
-            EBox::Sudo::root("chown $keytabUser:$keytabGroup '$path'");
+            EBox::Sudo::root("chown $keytabUser:proxy '$path'");
             EBox::Sudo::root("chmod 440 '$path'");
         }
     } catch ($e) {


### PR DESCRIPTION
This was needed as with existing code, keytab was set up as ebox:root, which
squid was not able to read