### PR TITLE
Fixes to allow proxy in REST calls

### DIFF
--- a/extra/scripts/docker/Dockerfile
+++ b/extra/scripts/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN echo "deb http://de.archive.ubuntu.com/ubuntu precise main universe" >> /etc
 RUN echo "deb http://de.archive.ubuntu.com/ubuntu precise-updates main universe" >> /etc/apt/sources.list
 RUN echo "deb http://de.archive.ubuntu.com/ubuntu precise-security main universe" >> /etc/apt/sources.list
 RUN echo "deb http://ppa.launchpad.net/zentyal/3.0/ubuntu precise main" >> /etc/apt/sources.list
+RUN echo "deb http://archive.zentyal.org/zentyal-beta 3.0-proposed main" >> /etc/apt/sources.list
 RUN apt-get update -y
 
 #Installing basic and build dependencies

--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Add asString option to proxySettings method
 3.0.14
 	+ Disable TCP offloading for eth0
 3.0.11

--- a/main/remoteservices/ChangeLog
+++ b/main/remoteservices/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Fixes to allow proxy in REST calls
 3.0.29
 	+ Pinning kernels so they are updated with QA updates active
 	+ Fix warning on last inside an eval on automatic-conf-backup script

--- a/main/remoteservices/debian/precise/control
+++ b/main/remoteservices/debian/precise/control
@@ -8,12 +8,12 @@ Standards-Version: 3.9.2
 Package: zentyal-remoteservices
 Architecture: all
 Replaces: ebox-remoteservices (<< 2.0.100)
-Depends: zentyal-core (>= 3.0.25), zentyal-core (<< 3.0.100), zentyal-monitor (>= 3.0.1),
+Depends: zentyal-core (>= 3.0.25), zentyal-core (<< 3.0.100), zentyal-network (>= 3.0.15), zentyal-monitor (>= 3.0.1),
  zentyal-firewall (>= 3.0.5), zentyal-openvpn, zentyal-software, libarchive-tar-perl, libsoap-lite-perl, libnet-dns-perl,
  liblinux-inotify2-perl, libdigest-sha-perl, libdate-calc-perl, libtext-csv-perl, screen,
  john (>= 1.7.6), libapt-pkg-perl, apache2 (>= 2.2.14-5ubuntu8.2), curl, at, libwww-perl,
  libfile-copy-recursive-perl, libossp-uuid-perl, apt-transport-https, ocsinventory-agent,
- pciutils, dmidecode, ${misc:Depends}
+ pciutils, dmidecode, liblwp-protocol-connect-perl, ${misc:Depends}
 Description: Zentyal - Cloud Client
  Zentyal is a Linux small business server that can act as
  a Gateway, Unified Threat Manager, Office Server, Infrastructure


### PR DESCRIPTION
- Fixed some error setting up proxy parameters
- Using liblwp-protocol-connect-perl to allow correct https connections through proxy