### PR TITLE
Added missing table-helper.js dependency to treeView template

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Added missing table-helper.js dependency to treeView template
 3.2.17
 	+ Improved upgrade script, removing not supported packages
 	  and moving stubs and hooks to backup

--- a/main/core/src/templates/ajax/treeView.mas
+++ b/main/core/src/templates/ajax/treeView.mas
@@ -8,6 +8,7 @@
   my $treeViewerId = "treeviewer_" . $model->name();
 </%init>
 <script type="text/javascript" src="/data/js/form.js"></script>
+<script type="text/javascript" src="/data/js/table-helper.js"></script>
 
 <& .pageTitle, title => $model->pageTitle() &>
 <& .message, model => $model &>


### PR DESCRIPTION
This should be also cherry-picked to more modern versions, becuase all of them have this problem.

The problem has not been seen because if some other template loads table-helper.js does not occur. A good way to reproduce it is to go directly to the users panel and click in the quota select. It gives a "Uncaught TypeError: Cannot read property 'showSelected' of undefinedonchange @ Manage:1" if table-helper.js is not loaded.