### PR TITLE
Remove Clone::Fast dependency and use Storable dclone

### DIFF
--- a/contrib/ha/src/EBox/HA/NodeList.pm
+++ b/contrib/ha/src/EBox/HA/NodeList.pm
@@ -24,7 +24,7 @@ use warnings;
 
 package EBox::HA::NodeList;
 
-use Clone::Fast;
+use Storable qw(dclone);
 use EBox::Exceptions::DataNotFound;
 use EBox::Exceptions::InvalidType;
 use List::Util qw(max);
@@ -271,7 +271,7 @@ sub diff
     my %other = map { $_->{name} => $_ } @{$other};
     my %mine = ();
     if (exists($state->{cluster_conf}->{nodes})) {
-        %mine = %{Clone::Fast::clone($state->{cluster_conf}->{nodes})};
+        %mine = %{dclone($state->{cluster_conf}->{nodes})};
     }
 
     my $equal = Test::Deep::eq_deeply(\%mine, \%other);

--- a/contrib/monitor/src/EBox/Monitor/Measure/t/Base.t
+++ b/contrib/monitor/src/EBox/Monitor/Measure/t/Base.t
@@ -17,7 +17,7 @@
 
 # A module to test Base measure module
 
-use Clone::Fast;
+use Storable qw(dclone);
 use EBox;
 use EBox::Gettext;
 use File::Temp;
@@ -106,7 +106,7 @@ foreach my $printableMethod (qw(printableInstance printableTypeInstance)) {
 
 # Data set, typeInstances, printable ones bad types
 foreach my $attr (qw(dataSources types instances printableLabels printableInstances printableTypeInstances printableDataSources)) {
-    my $badDescription = Clone::Fast::clone($greatDescription);
+    my $badDescription = dclone($greatDescription);
     $badDescription->{$attr} = 'foo';
     throws_ok {
         $measure->_setDescription($badDescription);
@@ -114,7 +114,7 @@ foreach my $attr (qw(dataSources types instances printableLabels printableInstan
 }
 
 # graphPerTypeInstance
-my $badDescription = Clone::Fast::clone($greatDescription);
+my $badDescription = dclone($greatDescription);
 $badDescription->{typeInstances} = [];
 $badDescription->{printableTypeInstances} = [];
 $badDescription->{graphPerTypeInstance} = 1;
@@ -124,7 +124,7 @@ throws_ok {
 
 # Printable instances (data source, type and measures)
 foreach my $kind (qw(printableInstances printableTypeInstances printableDataSources)) {
-    my $badDescription = Clone::Fast::clone($greatDescription);
+    my $badDescription = dclone($greatDescription);
     $badDescription->{$kind} = { 'tmp' => 'foo',
                                  'bar' => 'baz' };
     throws_ok {
@@ -133,7 +133,7 @@ foreach my $kind (qw(printableInstances printableTypeInstances printableDataSour
 }
 
 # Printable label
-$badDescription = Clone::Fast::clone($greatDescription);
+$badDescription = dclone($greatDescription);
 $badDescription->{printableLabels} = [ 'foo', 'bar' ];
 throws_ok {
     $measure->_setDescription($badDescription);
@@ -148,7 +148,7 @@ foreach my $type (qw(int percentage degree byte)) {
     cmp_ok( $measure->{type}, 'eq', $type);
 }
 
-$badDescription = Clone::Fast::clone($greatDescription);
+$badDescription = dclone($greatDescription);
 $badDescription->{type} = 'foo';
 throws_ok {
     $measure->_setDescription($badDescription);

--- a/contrib/trafficshaping/ChangeLog
+++ b/contrib/trafficshaping/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Replaced deprecated Clone::Fast with Storage's dclone
 4.0
 	+ Set version to 4.0
 	+ Added migration which get rid of deprecated l7 rules

--- a/contrib/trafficshaping/debian/control
+++ b/contrib/trafficshaping/debian/control
@@ -10,7 +10,7 @@ Architecture: all
 Replaces: ebox-trafficshaping (<< 2.0.100)
 Pre-Depends: zentyal-core
 Depends: zentyal-core (>= 4.0), zentyal-core (<< 4.1), zentyal-firewall,
-         libtree-perl, libclone-fast-perl, ${misc:Depends}
+         libtree-perl, ${misc:Depends}
 Description: Zentyal - Traffic Shaping
  Zentyal is a Linux small business server that can act as
  a Gateway, Unified Threat Manager, Office Server, Infrastructure

--- a/contrib/trafficshaping/src/EBox/TrafficShaping/TreeBuilder/HTB.pm
+++ b/contrib/trafficshaping/src/EBox/TrafficShaping/TreeBuilder/HTB.pm
@@ -42,8 +42,7 @@ use EBox::Iptables;
 
 use EBox::Gettext;
 
-# Dependencies
-use Clone::Fast;
+use Storable qw(dclone);
 
 use constant R2Q => EBox::Config::configkey('r2q');
 
@@ -962,7 +961,7 @@ sub _createInternalStructure # (defaultClassId)
     my $defaultClass = new EBox::TrafficShaping::Class(
                                                        minorNumber      => $defaultClassId,
                                                        parent           => $parentUserDefinedNode,
-                                                       queueDiscipline  => Clone::Fast::clone($parentUserDefinedHTB),
+                                                       queueDiscipline  => dclone($parentUserDefinedHTB),
                                                        qdiscAttached    => $leafDefaultQDisc,
                                                       );
     $self->{defaultClass} = $defaultClass;

--- a/extra/scripts/zentyal-unit-tests
+++ b/extra/scripts/zentyal-unit-tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PERLLIBS="test-mockmodule test-mockobject test-differences test-file test-mocktime test-tester test-cmd test-output test-class log-log4perl devel-stacktrace gd-gd2 config-tiny params-validate perl6-junction file-slurp readonly mail-rfc822-address io-interface data-validate-domain clone-fast html-mason proc-processtable test-deep dbi json json-xs yaml-libyaml redis linux-inotify2 sys-cpuload filesys-df authen-simple-pam nmap-parser dir-self file-readbackwards chart date-calc test-net-ldap soap-lite string-shellquote trycatch-lite string-random text-dhcpleases class-singleton xml-libxml plack test-sharedfork"
+PERLLIBS="test-mockmodule test-mockobject test-differences test-file test-mocktime test-tester test-cmd test-output test-class log-log4perl devel-stacktrace gd-gd2 config-tiny params-validate perl6-junction file-slurp readonly mail-rfc822-address io-interface data-validate-domain html-mason proc-processtable test-deep dbi json json-xs yaml-libyaml redis linux-inotify2 sys-cpuload filesys-df authen-simple-pam nmap-parser dir-self file-readbackwards chart date-calc test-net-ldap soap-lite string-shellquote trycatch-lite string-random text-dhcpleases class-singleton xml-libxml plack test-sharedfork"
 
 ADDITIONAL_ARGS=""
 EXTRA_ARGS="-j4"

--- a/main/core/debian/control
+++ b/main/core/debian/control
@@ -15,7 +15,7 @@ Pre-Depends: mysql-server
 Depends: zentyal-common (>= 4.1), zentyal-common (<< 4.2),
          adduser, apport, anacron, cracklib-runtime, cron, curl, dbus, debconf, gpgv,
          libapt-pkg-perl, libauthen-simple-pam-perl,
-         libcgi-emulate-psgi-perl, libclass-singleton-perl, libclone-fast-perl,
+         libcgi-emulate-psgi-perl, libclass-singleton-perl,
          libdatetime-timezone-perl,
          libdbd-mysql-perl, libfile-copy-recursive-perl, libfile-mmagic-perl,
          libfilesys-df-perl, libhttp-date-perl, libjson-perl,

--- a/main/core/src/EBox/Model/DataTable.pm
+++ b/main/core/src/EBox/Model/DataTable.pm
@@ -41,7 +41,7 @@ use EBox::Sudo;
 use EBox::Types::Boolean;
 use EBox::WebAdmin::UserConfiguration;
 
-use Clone::Fast;
+use Storable qw(dclone);
 use Encode;
 use TryCatch::Lite;
 use POSIX qw(ceil INT_MAX);
@@ -3768,7 +3768,7 @@ sub _checkMethodSignature # (action, methodName, paramsRef)
 {
     my ($self, $action, $methodName, $oldParamsRef) = @_;
 
-    my $paramsRef = Clone::Fast::clone($oldParamsRef);
+    my $paramsRef = dclone($oldParamsRef);
 
     # Delete the action from the name
     my $first = ( $methodName =~ s/^$action// );
@@ -4039,7 +4039,7 @@ sub _autoloadActionSubModel # (action, methodName, paramsRef)
 {
     my ($self, $action, $methodName, $origParamsRef) = @_;
 
-    my $paramsRef = Clone::Fast::clone($origParamsRef);
+    my $paramsRef = dclone($origParamsRef);
 
     $methodName =~ s/^$action//;
 

--- a/main/core/src/EBox/Types/Abstract.pm
+++ b/main/core/src/EBox/Types/Abstract.pm
@@ -32,7 +32,7 @@ package EBox::Types::Abstract;
 
 use EBox;
 
-use Clone::Fast;
+use Storable qw(dclone);
 use Scalar::Util 'weaken';
 use File::Basename;
 
@@ -83,7 +83,7 @@ sub clone
     my @suspectedAttrs = qw(model row);
     foreach my $key (keys %{$self}) {
         if ($key ne 'model' and $key ne 'row') {
-            $clonedType->{$key} = Clone::Fast::clone($self->{$key});
+            $clonedType->{$key} = dclone($self->{$key});
         }
     }
     # Just copy the reference

--- a/main/core/src/EBox/Types/Composite.pm
+++ b/main/core/src/EBox/Types/Composite.pm
@@ -36,7 +36,7 @@ use base 'EBox::Types::Abstract';
 use EBox::Exceptions::Internal;
 
 # Dependencies
-use Clone::Fast;
+use Storable qw(dclone);
 use Perl6::Junction qw(none);
 
 # Group: Public methods
@@ -89,7 +89,7 @@ sub clone
     my @suspectedAttrs = qw(model row types);
     foreach my $key (keys %{$self}) {
         if ( $key eq none(@suspectedAttrs) ) {
-            $clonedType->{$key} = Clone::Fast::clone($self->{$key});
+            $clonedType->{$key} = dclone($self->{$key});
         }
     }
     # Just copy the reference to the suspected attributes

--- a/main/core/src/EBox/Types/Union.pm
+++ b/main/core/src/EBox/Types/Union.pm
@@ -31,7 +31,7 @@ use EBox;
 use EBox::Exceptions::Internal;
 
 # Dependencies
-use Clone::Fast;
+use Storable qw(dclone);
 use Perl6::Junction qw(none);
 
 # It's a package global
@@ -79,7 +79,7 @@ sub clone
     my @suspectedAttrs = qw(model row subtypes);
     foreach my $key (keys %{$self}) {
         if ( $key eq none(@suspectedAttrs) ) {
-            $clonedType->{$key} = Clone::Fast::clone($self->{$key});
+            $clonedType->{$key} = dclone($self->{$key});
         }
     }
     # Just copy the reference

--- a/main/firewall/ChangeLog
+++ b/main/firewall/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Replaced deprecated Clone::Fast with Storage's dclone
 4.1
 	+ Set version to 4.1
 4.0

--- a/main/firewall/src/EBox/Firewall/IptablesRule.pm
+++ b/main/firewall/src/EBox/Firewall/IptablesRule.pm
@@ -28,7 +28,7 @@ package EBox::Firewall::IptablesRule;
 use warnings;
 use strict;
 
-use Clone::Fast;
+use Storable qw( dclone );
 
 use EBox::Validate qw( checkCIDR );
 use EBox::Model::Manager;
@@ -628,7 +628,7 @@ sub clone
     my @skipKeys = qw/services objects/;
     foreach my $key (keys %{$self}) {
         unless ($key eq any @skipKeys) {
-            $clonedRule->{$key} = Clone::Fast::clone($self->{$key});
+            $clonedRule->{$key} = dclone($self->{$key});
         }
     }
     for my $key (@skipKeys) {


### PR DESCRIPTION
As stated by the author of Clone::Fast is deprecated ( https://github.com/hallta/Clone-Fast#deprecation ).

In addition to that, it is unstable and incompatible with Perl API since 5.11 as shown (http://matrix.cpantesters.org/?dist=Clone-Fast%200.97).

As a replacement I propose to use (as a intermediate solution) Storable dclone. It is part of Perl core modules since Perl 5.8. And might not be affected by a memory leak, as so reasoned within the history for Clone::Fast (http://search.cpan.org/~jjore/Clone-Fast-0.96/lib/Clone/Fast.pm#HISTORY).

The slight performance decrease might be arguable, but as long as the Clone::Fast is not maintained and Clone is not endurable (rebooting a Zentyal server might not be a good maintenance advice), I would advise to stay with Storable dclone.

An alternative would be to benchmark Clone::PP and see how stable this module is.

Cheers,
π
