### PR TITLE
Fixed wrong call to exception's 'exitValue' method in EBox::TC package

### DIFF
--- a/main/trafficshaping/ChangeLog
+++ b/main/trafficshaping/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Fixed wrong call to exception's 'exitValue' method in EBox::TC package
 4.0
 	+ Set version to 4.0
 	+ Added migration which get rid of deprecated l7 rules

--- a/main/trafficshaping/src/EBox/TC.pm
+++ b/main/trafficshaping/src/EBox/TC.pm
@@ -74,16 +74,15 @@ sub tc
 
     try {
         EBox::Sudo::root(TC_CMD . " $opts");
-    } catch (EBox::Exceptions::Sudo::Command $e) {
+    } catch (EBox::Exceptions::Sudo::Command $ex) {
         # Catching exception from tc command
-        my $exception = shift;
-        if ( $exception->exitValue() == 2 ) {
+        if ($ex->exitValue() == 2) {
             # RTNETLINK answers: No such file or directory
             # Trying to delete qdisc where nothing it is in
             EBox::warn("No qdisc to remove");
         }
         else {
-            $exception->throw();
+            $ex->throw();
         }
     }
 }


### PR DESCRIPTION
This affects version >= 3.3. It should be cherry picked for all the mantained versions