### PR TITLE
[Samba] GlusterFS has acl and extended attributes by default

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Added GlusterFS as fs with acl and extended attributes by default
 	+ Corrected check for value of listen_all config key
 	+ Corrected name for default containers
 	+ Added EBox::LdapUserBase::objectInDefaultContainer

--- a/main/samba/src/EBox/Samba/Model/SambaShares.pm
+++ b/main/samba/src/EBox/Samba/Model/SambaShares.pm
@@ -485,8 +485,8 @@ sub _checkSystemShareMountOptions
         }
     }
 
-    # BTRFS and XFS have acl and extended attributes by default
-    if (($type =~ m/btrfs/) or ($type =~ m/xfs/)) {
+    # BTRFS, XFS and GlusterFS have acl and extended attributes by default
+    if (($type =~ m/btrfs/) or ($type =~ m/xfs/) or ($type =~ m/glusterfs/)) {
         return 1;
     }
 


### PR DESCRIPTION
It solves a bug when a samba resource is shared but mounted with glusterfs. Error message was: "The mount point '/mnt/test' must be mounted with 'acl' option. This is required for permissions to work properly."

But GlusterFS supports it.

references:
- [ACL](http://www.gluster.org/community/documentation/index.php/Access_Control_Lists)
- [Extended Attributes through RichACL](http://www.gluster.org/community/documentation/index.php/Features/RichACL). Note: I don't know exactly if EA is supported in gluster