### PR TITLE
Add no lock for dump databases

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Added skip-lock-tables,quick and single-transaction parameters to
+	mysqldump command when dumping databases
 4.1.3
 	+ Added JS function Zentyal.escapeHTTPQuery
 4.1.2

--- a/main/core/src/EBox/MyDBEngine.pm
+++ b/main/core/src/EBox/MyDBEngine.pm
@@ -694,7 +694,7 @@ sub  dumpDB
     if ($onlySchema) {
         $args .= ' --no-data';
     }
-    $args .= " -h$dbhost";
+    $args .= " -h$dbhost --skip-lock-tables";
     
     my $dumpCommand = "mysqldump $args $dbname > $tmpFile";
 

--- a/main/core/src/EBox/MyDBEngine.pm
+++ b/main/core/src/EBox/MyDBEngine.pm
@@ -694,7 +694,7 @@ sub  dumpDB
     if ($onlySchema) {
         $args .= ' --no-data';
     }
-    $args .= " -h$dbhost --skip-lock-tables";
+    $args .= " -h$dbhost --skip-lock-tables --quick --single-transaction";
     
     my $dumpCommand = "mysqldump $args $dbname > $tmpFile";
 


### PR DESCRIPTION
This is needed, as otherwise configuration backups will fail for long sogo databases