### PR TITLE
Fix possible redis corruption

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,6 @@
+HEAD
+	+ Fix possible redis corruption when deleting data table rows
+	  with ids sharing the same prefix
 4.1.4
 	+ Remove non-numeric value warning in data table size control
 	+ Added skip-lock-tables, quick and single-transaction parameters to

--- a/main/core/src/EBox/Config/Redis.pm
+++ b/main/core/src/EBox/Config/Redis.pm
@@ -239,6 +239,10 @@ sub _keys
         not $deleted{$key}
     } $self->_redis_call('keys', $pattern);
 
+    if (($pattern =~ /\*$/) or ($pattern =~ /\/$/)) {
+        chop ($pattern);
+    }
+
     foreach my $name (keys %cache) {
         if ($name =~ /^$pattern/) {
             push (@keys, $name);


### PR DESCRIPTION
when deleting data table rows with ids sharing the same prefix