### PR TITLE
Set proper motd after edition name changes

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Set proper motd after edition name changes
 	+ Avoid XSS on search when entering JS code
 4.1.5
 	+ Fix possible redis corruption when deleting data table rows

--- a/main/core/src/EBox/RemoteServices.pm
+++ b/main/core/src/EBox/RemoteServices.pm
@@ -1013,7 +1013,7 @@ sub _updateMotd
          (subscribed => $self->eBoxSubscribed())
         );
     if ($self->eBoxSubscribed() ) {
-        push(@tmplParams, (editionMsg => __sx('This is a Zentyal Server {edition} edition.',
+        push(@tmplParams, (editionMsg => __sx('This is a Zentyal Server ({edition}).',
                                                 edition => $self->i18nServerEdition())));
     }
     EBox::Module::Base::writeConfFileNoCheck(


### PR DESCRIPTION
Instead of having this messed up name:

     This is a Zentyal Server Zentyal Community Edition edition.

We will have:

     This is a Zentyal Server (Zentyal Community Edition).