### PR TITLE
Fix high cpu usage on system startup

### DIFF
--- a/main/network/src/scripts/flush-fwmarks
+++ b/main/network/src/scripts/flush-fwmarks
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for i in $(ip rule ls | cut -d: -f 1); do 
+for i in $(timeout 5 ip rule ls | cut -d: -f 1 | uniq); do 
 	if [ $i -gt 0 -a $i -le 32765 ]; then
 		ip rule del pref $i; 
 	fi; 


### PR DESCRIPTION
Added `timeout` and `uniq` to `ip rule ls` parsing, on some systems (perhaps an Ubuntu bug) the output is neverending and results in a infinite loop.