### PR TITLE
Fix warning on server edition widget from registered users

### DIFF
--- a/main/core/ChangeLog
+++ b/main/core/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Fix warning on server edition widget from registered users
 4.2
 	+ Set proper motd after edition name changes
 	+ Avoid XSS on search when entering JS code

--- a/main/core/src/EBox/RemoteServices.pm
+++ b/main/core/src/EBox/RemoteServices.pm
@@ -208,6 +208,9 @@ sub technicalSupport
             $subscriptionInfo = $self->subscriptionInfo;
         }
         $level = $subscriptionInfo->{features}->{technical_support}->{level};
+        unless (defined($level)) {
+            $level = -1;
+        }
     } catch ($ex) {
         EBox::error("Error getting technical support level: $ex");
     }


### PR DESCRIPTION
This will remove this warning message:

      2015/11/07 10:49:15 WARN> zentyal.psgi:43 main::__ANON__ - Use of uninitialized value in hash element at /usr/share/perl5/EBox/RemoteServices.pm line 1329.