### PR TITLE
Fixing the /etc/resolv.conf empty lines bug.

### DIFF
--- a/main/core/src/EBox/SysInfo/Model/HostName.pm
+++ b/main/core/src/EBox/SysInfo/Model/HostName.pm
@@ -139,6 +139,9 @@ sub _readResolv
     for my $line (<$resolvFH>) {
         $line =~ s/^\s+//g;
         my @toks = split (/\s+/, $line);
+        if (@toks < 2) {
+            next;
+        }
         if ($toks[0] eq 'nameserver') {
             push (@dns, $toks[1]);
         } elsif ($toks[0] eq 'search') {

--- a/main/core/src/EBox/SysInfo/Model/ManageAdmins.pm
+++ b/main/core/src/EBox/SysInfo/Model/ManageAdmins.pm
@@ -86,7 +86,7 @@ sub ids
 sub row
 {
     my ($self, $id) = @_;
-    if (not $id) {
+    if (not defined $id) {
         throw EBox::Exceptions::MissingArgument('id');
     }
     my $username = getpwuid($id);
@@ -125,11 +125,11 @@ sub addTypedRow
         my $userNotExists = $?;
         if ($userNotExists) {
             _rootWithExternalEx("adduser --disabled-password --gecos '' $user");
-            
+
             my $password = $params->{password}->value();
             $self->_changePassword($user, $password);
         }
-        
+
         unless ($self->_userIsAdmin($user)) {
             _rootWithExternalEx("adduser $user $ADMIN_GROUP");
             my $audit = EBox::Global->modInstance('audit');
@@ -145,7 +145,7 @@ sub addTypedRow
                        user => $user);
         } else {
             $msg = __x('User "{user}" granted Zentyal administrative permissions',
-                       user => $user);            
+                       user => $user);
         }
         $self->setMessage($msg);
 
@@ -166,19 +166,19 @@ sub setTypedRow
 
         my $user = $params->{username}->value();
         my $oldName = getpwuid($id);
-        
+
         if ($user ne $oldName) {
             _rootWithExternalEx("usermod -l $user $oldName");
             my $audit = EBox::Global->modInstance('audit');
             $audit->logAction('System', 'General', 'changeLogin', "$oldName -> $user", 0);
         }
 
-        
+
         my $password = $params->{password}->value();
         if ($password) {
             $self->_changePassword($user, $password);
         }
-        
+
         $self->SUPER::setTypedRow($id, $params);
     } catch ($ex) {
         EBox::Exceptions::Base::rethrowSilently($ex);


### PR DESCRIPTION
This fixes a bug when there are empty lines in /etc/resolv.conf, because otherwise the following is written to the log file:

```
Use of uninitialized value $toks[0] in string eq at /usr/share/perl5/EBox/SysInfo/Model/HostName.pm line 142, <$resolvFH> line 9.
```