### PR TITLE
Error when running under the root user.

### DIFF
--- a/main/core/src/EBox/SysInfo/Model/HostName.pm
+++ b/main/core/src/EBox/SysInfo/Model/HostName.pm
@@ -139,6 +139,9 @@ sub _readResolv
     for my $line (<$resolvFH>) {
         $line =~ s/^\s+//g;
         my @toks = split (/\s+/, $line);
+        if (@toks < 2) {
+            next;
+        }
         if ($toks[0] eq 'nameserver') {
             push (@dns, $toks[1]);
         } elsif ($toks[0] eq 'search') {

--- a/main/core/src/EBox/SysInfo/Model/ManageAdmins.pm
+++ b/main/core/src/EBox/SysInfo/Model/ManageAdmins.pm
@@ -86,7 +86,7 @@ sub ids
 sub row
 {
     my ($self, $id) = @_;
-    if (not $id) {
+    if (not defined $id) {
         throw EBox::Exceptions::MissingArgument('id');
     }
     my $username = getpwuid($id);
@@ -125,11 +125,11 @@ sub addTypedRow
         my $userNotExists = $?;
         if ($userNotExists) {
             _rootWithExternalEx("adduser --disabled-password --gecos '' $user");
-            
+
             my $password = $params->{password}->value();
             $self->_changePassword($user, $password);
         }
-        
+
         unless ($self->_userIsAdmin($user)) {
             _rootWithExternalEx("adduser $user $ADMIN_GROUP");
             my $audit = EBox::Global->modInstance('audit');
@@ -145,7 +145,7 @@ sub addTypedRow
                        user => $user);
         } else {
             $msg = __x('User "{user}" granted Zentyal administrative permissions',
-                       user => $user);            
+                       user => $user);
         }
         $self->setMessage($msg);
 
@@ -166,19 +166,19 @@ sub setTypedRow
 
         my $user = $params->{username}->value();
         my $oldName = getpwuid($id);
-        
+
         if ($user ne $oldName) {
             _rootWithExternalEx("usermod -l $user $oldName");
             my $audit = EBox::Global->modInstance('audit');
             $audit->logAction('System', 'General', 'changeLogin', "$oldName -> $user", 0);
         }
 
-        
+
         my $password = $params->{password}->value();
         if ($password) {
             $self->_changePassword($user, $password);
         }
-        
+
         $self->SUPER::setTypedRow($id, $params);
     } catch ($ex) {
         EBox::Exceptions::Base::rethrowSilently($ex);


### PR DESCRIPTION
The problem is in EBox/SysInfo/Model/ManageAdmins.pm, where the ids function first gets the users from the *sudo* group  with *getgrname* function. Then it takes those users and get the ID of each and every using with *getpwname*, including the root user, which effectively has the ID of 0.

```
sub ids
{
    my ($self) = @_;
    my (undef, undef, undef, $usersField) = getgrnam($ADMIN_GROUP);
    my @users = split ('\s', $usersField);
    my @ids = map {
        my $id = getpwnam($_);
        (defined $id) ? ($id) : ();
    } @users;
    return \@ids;
}
```

Then when the entries are being processed by the row function, the function checks if the argument is false, in which case it throws the exception. The problem is that the 0 is also being regarded as false, so the "not false" evaluates to true and exception is thrown when the root user belongs to the sudo group.

```
sub row
{
    my ($self, $id) = @_;
    if (not $id) {
        throw EBox::Exceptions::MissingArgument('id');
    }
...
```

To solve the problem, we have to add the *defined* keyword, which would actually check if the argument is defined, therefore when it is 0, the whole expression will evaluate to false and the exception will not be thrown.

```
sub row
{
    my ($self, $id) = @_;
    if (not defined $id) {
        throw EBox::Exceptions::MissingArgument('id');
    }
...
```

I realize that it doesn't make sense that a user *root* belongs to the *sudo* group, but ti isn't up to the Zentyal to decide that. If a user wants to add user root to the sudo group, it should work without breaking Zentyal.

I've spend a number of hours tracking down this problem as it has bugged me for some time now. This is effectively the bug that has been reported before, so now it can be properly solved: https://tracker.zentyal.org/issues/3499.

Therefore, I propose a fix to eliminate this nasty problem once and for all.