### PR TITLE
Added timeout to flush-fwmarks script

### DIFF
--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Added timeout to flush-fwmarks script
 4.2
 	+ Update version to 4.2
 4.1.1

--- a/main/network/src/scripts/flush-fwmarks
+++ b/main/network/src/scripts/flush-fwmarks
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-for i in $(ip rule ls | cut -d: -f 1); do 
+rules=`timeout 10 ip rule ls |  cut -d: -f1`
+for i in $rules; do 
 	if [ $i -gt 0 -a $i -le 32765 ]; then
 		ip rule del pref $i; 
 	fi; 


### PR DESCRIPTION
This is needed because there is a iptable bug which gives a infinite output. If we trigger it and we have not timeout it breaks the zentyal-network save changes process.
