### PR TITLE
Set up services certificates when a new CA is created

### DIFF
--- a/main/ca/ChangeLog
+++ b/main/ca/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Set up services certificates when a new CA is created
 4.2
 	+ Update version to 4.2
 4.1

--- a/main/ca/src/EBox/CA.pm
+++ b/main/ca/src/EBox/CA.pm
@@ -327,6 +327,8 @@ sub createCA
     #unlink (CAREQ);
     $self->_setPasswordRequired(defined($self->{caKeyPassword}));
 
+    $self->model('Certificates')->notifyNewCA();    
+
     return 1;
 }
 


### PR DESCRIPTION
This has two advantages:
- It allows to set up services certificates before CA is created thus
  making easier the user operation.
- If we remove manually the CA and create a new one, the service
  certificates are correctly issued.