### PR TITLE
Changes in management of network cron script to avoid locks

### DIFF
--- a/main/network/ChangeLog
+++ b/main/network/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Avoid race condition between saving changes and failover cron job
 4.2
 	+ Update version to 4.2
 4.1.1


### PR DESCRIPTION
If the frequency of the failover check is too short, or the old
frecuency was, it can overlap the saving changes process and
give various problems.

To avoid this siutation we remove the cron file when we begin to save the
changes and we delay its writng to the last moment.