### PR TITLE
Add systemQuotas object class when setting user quota

### DIFF
--- a/main/samba/ChangeLog
+++ b/main/samba/ChangeLog
@@ -1,4 +1,5 @@
 HEAD
+	+ Add systemQuota object class when setting user quota
 	+ Added explicit check for full name in EBox::Samba::User::create
 4.2.1
 	+ Remove External AD mode leftovers in menu when not configured

--- a/main/samba/src/EBox/Samba/CGI/EditUser.pm
+++ b/main/samba/src/EBox/Samba/CGI/EditUser.pm
@@ -75,7 +75,10 @@ sub _process
         } elsif ($quotaTypeSelected eq 'quota_size') {
             $quota = $self->param('User_quota_size');
         }
-        if (defined ($quota) and $user->hasValue('objectClass', 'systemQuotas')) {
+        if (defined $quota) {
+            if (not $user->hasValue('objectClass', 'systemQuotas')) {
+                $user->add('objectClass', 'systemQuotas');
+            }
             $user->set('quota', $quota, 1);
         }
 


### PR DESCRIPTION
When adding users by means other than Zentyal interface is frequent
that users are missing the systemQuotas object class.
Without this class the user quota cannot be set, so this changeset
make sure to add it if needed.