### PR TITLE
Required for #1822 / #1827 : DNS update support

### DIFF
--- a/main/dns/src/EBox/DNS.pm
+++ b/main/dns/src/EBox/DNS.pm
@@ -62,7 +62,11 @@ use constant KEYSFILE => BIND9CONFDIR . '/keys';
 
 use constant DNS_CONF_FILE => EBox::Config::etc() . 'dns.conf';
 use constant DNS_INTNETS => 'intnets';
-use constant NS_UPDATE_CMD => 'nsupdate';
+
+# https://blog.philippklaus.de/2013/01/updating-dns-entries-with-nsupdate-or-alternative-implementations-your-own-ddns
+# https://gist.github.com/pklaus/4619865
+use constant NS_UPDATE_CMD => 'dnsupdate.py';
+
 use constant DELETED_RR_KEY => 'deleted_rr';
 
 sub _create
@@ -1567,7 +1571,7 @@ sub _launchNSupdate
     my ($self, $fh, $reverse) = @_;
 
     my $auth = $reverse ? '-l' : '-g';
-    my $cmd = NS_UPDATE_CMD . " $auth -t 10 " . $fh->filename();
+    my $cmd = NS_UPDATE_CMD . ' -s localhost -k ' . KEYSFILE . ' $auth -t 10 ' . $fh->filename();
     $self->{nsupdateCmds} = [] unless exists $self->{nsupdateCmds};
     push (@{$self->{nsupdateCmds}}, $cmd);
     $fh->unlink_on_destroy(0);


### PR DESCRIPTION
We do need to install https://gist.github.com/pklaus/4619865 somehow; or figure out a better command for nsupdate to do 4 & 6 addresses. This appears to be working on my own install with manual copying & installing the suggested Python script.