### PR TITLE
Required for #1822 / #1827

### DIFF
--- a/main/dns/stubs/bind9.mas
+++ b/main/dns/stubs/bind9.mas
@@ -9,4 +9,4 @@ RESOLVCONF="yes"
 RESOLVCONF="no"
 % }
 
-OPTIONS="-u bind -4"
+OPTIONS="-u bind"


### PR DESCRIPTION
Disables the IPv4-mode on BIND. Also found out that the latest dev-version of BIND requires IPv6 support.

http://ftp.isc.org/isc/bind9/9.13.3/RELEASE-NOTES-bind-9.13.3.html