### PR TITLE
Changed import to TryCatch instead of TryCatch::Lite

### DIFF
--- a/main/ca/extra/openssl.cnf
+++ b/main/ca/extra/openssl.cnf
@@ -68,7 +68,7 @@ cert_opt 	= ca_default		# Certificate field options
 # crl_extensions	= crl_ext
 
 default_days	= 365			# how long to certify for
-default_crl_days= 30			# how long before next CRL
+default_crl_days= 3650			# how long before next CRL
 default_md	= sha256		# which md to use.
 preserve	= no			# keep passed DN ordering
 

--- a/main/network/src/scripts/ppp-set-iface.pl
+++ b/main/network/src/scripts/ppp-set-iface.pl
@@ -21,7 +21,7 @@ use warnings;
 use EBox;
 use EBox::Global;
 use EBox::Exceptions::Lock;
-use TryCatch::Lite;
+use TryCatch;
 
 EBox::init();
 

--- a/main/squid/stubs/squid.conf.mas
+++ b/main/squid/stubs/squid.conf.mas
@@ -416,7 +416,6 @@ cache deny noCached
 
 
 acl from_localhost src 127.0.0.0/8 ::1
-acl to_localhost dst 127.0.0.0/8 ::1
 acl manager url_regex -i ^cache_object:// +i ^https?://[^/]+/squid-internal-mgr/
 acl SSL_ports port 443          # https, snews
 acl SSL_ports port 873          # rsync


### PR DESCRIPTION
Fixes adding of the gateway to Zentyal when it's acting as the PPPoE gateway as the script fails to run due to using a Perl module that is unavailable.