### PR TITLE
Fix for #1923

### DIFF
--- a/main/openvpn/stubs/openvpn.conf.mas
+++ b/main/openvpn/stubs/openvpn.conf.mas
@@ -105,7 +105,7 @@ keepalive 10 120
 
 # client certificate common name authentication
 % if (defined $tlsRemote) {
-verify-x509-name <% $tlsRemote %> name
+verify-x509-name <% $tlsRemote %> name-prefix
 % }
 
 # For extra security beyond that provided


### PR DESCRIPTION
Refer to the comments about the value of "tlsRemote" in:

main/openvpn/src/EBox/OpenVPN/Model/ServerConfiguration.pm

which are reproduced here (highlighting mine):

> If **disabled**, any client with a certificate generated by Zentyal will be able to connect. If **enabled**, only certificates whose common name **begins** with the selected value will be able to connect.

This commit affects the second part of this statement: if defined, the server will validate that the client's certificate's name begins with the specified name (which is contained in tlsRemote).

(Whether tlsRemote is not defined or not, the client's certificate should still be checked that is was issued by the specified CA certificate. I have not changed this code.)