### PR TITLE
fixes port-forwarding and certificate issues

### DIFF
--- a/main/core/stubs/nginx.conf.mas
+++ b/main/core/stubs/nginx.conf.mas
@@ -112,7 +112,7 @@ http {
 
         ssl on;
         ssl_certificate <% $zentyalconfdir %>ssl/ssl.pem;
-        ssl_certificate_key <% $zentyalconfdir %>ssl/ssl.pem;
+        ssl_certificate_key <% $zentyalconfdir %>ssl/ssl.key;
 % if ($caFile) {
         ssl_client_certificate <% $caFile %>;
         ssl_verify_client optional;

--- a/main/virt/debian/zentyal.vncproxy.service
+++ b/main/virt/debian/zentyal.vncproxy.service
@@ -2,7 +2,7 @@
 Description=Zentyal vncproxy daemon
 
 [Service]
-ExecStart=/usr/bin/websockify --ssl-only --key=/var/lib/zentyal/conf/ssl/ssl.key --cert=/var/lib/zentyal/conf/ssl/ssl.pem --token-plugin TokenFile --token-source /var/lib/zentyal/conf/vnc-tokens --web /usr/share/novnc 6900
+ExecStart=/usr/share/zentyal-virt/certconf
 Restart=on-failure
 
 [Install]

--- a/main/virt/src/EBox/Virt.pm
+++ b/main/virt/src/EBox/Virt.pm
@@ -29,6 +29,7 @@ use EBox::Menu::Item;
 use EBox::Menu::Folder;
 use EBox::Sudo;
 use EBox::Util::Version;
+use EBox::Util::Init;
 use EBox::Dashboard::Section;
 use EBox::Virt::Dashboard::VMStatus;
 use EBox::Virt::Model::NetworkSettings;
@@ -292,6 +293,8 @@ sub startVM
     my ($self, $name) = @_;
 
     $self->_manageVM($name, 'start');
+
+    EBox::Util::Init::moduleRestart('firewall');
 }
 
 sub stopVM

--- a/main/virt/src/scripts/certconf
+++ b/main/virt/src/scripts/certconf
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Fix the  KEY_VALUES_MISMATCH error produced when the CA module is configured
+# The issue is produced because when generated the CA private key, it is copied
+# as /var/lib/zentyal/conf/ssl/ssl.key but the certificate corresponding to the
+# new key isn't issued 
+
+set -x
+
+readonly NOCAPEM=/var/lib/zentyal/conf/ssl/ssl.pem
+readonly NOCAKEY=/var/lib/zentyal/conf/ssl/ssl.key
+declare FLAG
+FLAG=0
+
+
+function check_modulus () {
+	modkey=$(openssl rsa -noout -modulus -in $NOCAKEY | openssl md5)
+	modcert=$(openssl x509 -noout -modulus -in $NOCAPEM | openssl md5)
+	if [[ $modkey == $modcert ]]
+	then
+		FLAG=1
+	fi
+}
+
+check_modulus
+
+if [[ $FLAG -eq 1  ]]
+then
+	/usr/bin/websockify --ssl-only --key=$NOCAKEY --cert=$NOCAPEM --token-plugin TokenFile --token-source /var/lib/zentyal/conf/vnc-tokens --web /usr/share/novnc 6900
+else
+	openssl req -key $NOCAKEY -new -x509 -days 365 -out $NOCAPEM -subj "/CN=Zentyal_vncproxy" &>/dev/null
+	if [[ $? -eq 0 ]]
+	then 
+		/usr/bin/websockify --ssl-only --key=$NOCAKEY --cert=$NOCAPEM --token-plugin TokenFile --token-source /var/lib/zentyal/conf/vnc-tokens --web /usr/share/novnc 6900
+	else
+		logger "Unable to create the required certificate for the zentyal.vpnproxy service"
+		exit 1
+	fi
+fi
+
+exit 0


### PR DESCRIPTION
Hi,

This fixes some issues on the Virt module:

- Mismatch of zentyal.vncproxy.service certificate when enabled CA
- Port forwarding issues on autostart virtual machines when Zentyal reboots  