### PR TITLE
Fixes FTP Module fails on install #1872

### DIFF
--- a/main/ftp/debian/control
+++ b/main/ftp/debian/control
@@ -12,6 +12,7 @@ Vcs-Git: https://github.com/zentyal/zentyal.git
 Package: zentyal-ftp
 Architecture: all
 Depends: zentyal-core (>= 6.2.0), zentyal-core (<< 7.0.0),
+	 zentyal-network, zentyal-firewall,
          vsftpd, ${misc:Depends}
 Description: Zentyal - FTP
  Zentyal is a Linux small business server that can act as

--- a/main/ftp/schemas/ftp.yaml
+++ b/main/ftp/schemas/ftp.yaml
@@ -1,4 +1,12 @@
 class: 'EBox::FTP'
 
+enabledepends:
+    - network
+    - firewall
+
+bootdepends:
+    - network
+    - firewall
+
 models:
     - Options


### PR DESCRIPTION
Configures the zentyal-ftp package to install and configure network packages before itself if chosen from the wizard.