### PR TITLE
Fixes configuration report date bug #1994

### DIFF
--- a/main/core/src/EBox/Backup.pm
+++ b/main/core/src/EBox/Backup.pm
@@ -827,7 +827,8 @@ sub _moveToArchives
 sub makeBugReport
 {
     my ($self) = @_;
-    return $self->_makeBackup(description => 'Bug report', 'bug' => 1);
+    my $time = time();
+    return $self->_makeBackup(description => 'Bug report', 'bug' => 1, time => $time);
 }
 
 # unpacks a backup file into a temporary directory and verifies the md5sum


### PR DESCRIPTION
The _makeBugReport_ subroutine didn't initialize the date and time.