### PR TITLE
Improve BIND9 logging

### DIFF
--- a/main/dns/stubs/named.conf.options.mas
+++ b/main/dns/stubs/named.conf.options.mas
@@ -47,4 +47,216 @@ options {
     allow-transfer { internal-local-nets; };
 };
 
-logging { category lame-servers { null; }; };
+logging {
+     channel default_log {
+          file "/var/log/named/default" versions 3 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+     channel auth_servers_log {
+          file "/var/log/named/auth_servers" versions 100 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+     channel dnssec_log {
+          file "/var/log/named/dnssec" versions 3 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+     channel zone_transfers_log {
+          file "/var/log/named/zone_transfers" versions 3 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+     channel ddns_log {
+          file "/var/log/named/ddns" versions 3 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+     channel client_security_log {
+          file "/var/log/named/client_security" versions 3 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+     channel rate_limiting_log {
+          file "/var/log/named/rate_limiting" versions 3 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+     channel rpz_log {
+          file "/var/log/named/rpz" versions 3 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+     channel dnstap_log {
+          file "/var/log/named/dnstap" versions 3 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+//
+// If you have the category ‘queries’ defined, and you don’t want query logging
+// by default, make sure you add option ‘querylog no;’ - then you can toggle
+// query logging on (and off again) using command ‘rndc querylog’
+//
+     channel queries_log {
+          file "/var/log/named/queries" versions 600 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity info;
+     };
+//
+// This channel is dynamic so that when the debug level is increased using
+// rndc while the server is running, extra information will be logged about
+// failing queries.  Other debug information for other categories will be
+// sent to the channel default_debug (which is also dynamic), but without
+// affecting the regular logging.
+//
+     channel query-errors_log {
+          file "/var/log/named/query-errors" versions 5 size 20m;
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          severity dynamic;
+     };
+//
+// This is the default syslog channel, defined here for clarity.  You don’t
+// have to use it if you prefer to log to your own channels.
+// It sends to syslog’s daemon facility, and sends only logged messages
+// of priority info and higher.
+// (The options to print time, category and severity are non-default.)
+//
+     channel default_syslog {
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          syslog daemon;
+          severity info;
+     };
+//
+// This is the default debug output channel, defined here for clarity.  You
+// might want to redefine the output destination if it doesn’t fit with your
+// local system administration plans for logging.  It is also a special
+// channel that only produces output if the debug level is non-zero.
+//
+     channel default_debug {
+          print-time yes;
+          print-category yes;
+          print-severity yes;
+          file "named.run";
+          severity dynamic;
+     };
+//
+// Log routine stuff to syslog and default log:
+//
+     category default { default_syslog; default_debug; default_log; };
+     category config { default_syslog; default_debug; default_log; };
+     category dispatch { default_syslog; default_debug; default_log; };
+     category network { default_syslog; default_debug; default_log; };
+     category general { default_syslog; default_debug; default_log; };
+//
+// From BIND 9.12 and newer, you can direct zone load logging to another
+// channel with the new zoneload logging category.  If this would be useful
+// then firstly, configure the new channel, and then edit the line below
+// to direct the category there instead of to syslog and default log:
+//
+//     category zoneload { default_syslog; default_debug; default_log; };
+//
+// Log messages relating to what we got back from authoritative servers during
+// recursion (if lame-servers and edns-disabled are obscuring other messages
+// they can be sent to their own channel or to null).  Sometimes these log
+// messages will be useful to research why some domains don’t resolve or
+// don’t resolve reliably
+//
+     category resolver { auth_servers_log; default_debug; };       
+     category cname { auth_servers_log; default_debug; };       
+     category delegation-only { auth_servers_log; default_debug; };
+     category lame-servers { auth_servers_log; default_debug; };
+     category edns-disabled { auth_servers_log; default_debug; };
+//
+// Log problems with DNSSEC:
+//
+     category dnssec { dnssec_log; default_debug; };
+//
+// Log together all messages relating to authoritative zone propagation
+//
+     category notify { zone_transfers_log; default_debug; };       
+     category xfer-in { zone_transfers_log; default_debug; };       
+     category xfer-out { zone_transfers_log; default_debug; };
+//
+// Log together all messages relating to dynamic updates to DNS zone data:
+//
+     category update{ ddns_log; default_debug; };
+     category update-security { ddns_log; default_debug; };
+//
+// Log together all messages relating to client access and security.
+// (There is an additional category ‘unmatched’ that is by default sent to
+// null but which can be added here if you want more than the one-line
+// summary that is logged for failures to match a view).
+//
+     category client{ client_security_log; default_debug; };       
+     category security { client_security_log; default_debug; };
+//
+// Log together all messages that are likely to be related to rate-limiting.
+// This includes RRL (Response Rate Limiting) - usually deployed on authoritative
+// servers and fetches-per-server|zone.  Note that it does not include
+// logging of changes for clients-per-query (which are logged in category
+// resolver).  Also note that there may on occasions be other log messages
+// emitted by the database category that don’t relate to rate-limiting
+// behaviour by named.
+//
+     category rate-limit { rate_limiting_log; default_debug; };       
+     category spill { rate_limiting_log; default_debug; };       
+     category database { rate_limiting_log; default_debug; };
+//
+// Log DNS-RPZ (Response Policy Zone) messages (if you are not using DNS-RPZ
+// then you may want to comment out this category and associated channel)
+//
+     category rpz { rpz_log; default_debug; };
+//
+// Log messages relating to the "dnstap" DNS traffic capture system  (if you
+// are not using dnstap, then you may want to comment out this category and
+// associated channel).
+//
+     category dnstap { dnstap_log; default_debug; };
+//
+// If you are running a server (for example one of the Internet root
+// nameservers) that is providing RFC 5011 trust anchor updates, then you
+// may be interested in logging trust anchor telemetry reports that your
+// server receives to analyze anchor propagation rates during a key rollover. 
+// If this would be useful then firstly, configure the new channel, and then
+// un-comment and the line below to direct the category there instead of to
+// syslog and default log:
+//
+//   category trust-anchor-telemetry { default_syslog; default_debug; default_log; };
+//
+// If you have the category ‘queries’ defined, and you don’t want query logging
+// by default, make sure you add option ‘querylog no;’ - then you can toggle
+// query logging on (and off again) using command ‘rndc querylog’
+//
+     category queries { queries_log; };
+//
+// This logging category will only emit messages at debug levels of 1 or
+// higher - it can be useful to troubleshoot problems where queries are
+// resulting in a SERVFAIL response.
+//
+     category query-errors {query-errors_log; };
+};


### PR DESCRIPTION
Updated BIND9 options to include sample logging rules as per <https://kb.isc.org/docs/aa-01526>, with the following exceptions:

1.  Logs are sent to `/var/log/named/*`, instead of the default `/var/named/log/*`.
2.  Removed categories `trust-anchor-telemetry` and `zoneload`, as these prevented BIND9 from launching under Zentyal 6.1

Directives include log file rolling, to reduce storage problems.