### PR TITLE
Security fix: LDAP authentication is not secure on its own.

### DIFF
--- a/main/radius/ChangeLog
+++ b/main/radius/ChangeLog
@@ -1,3 +1,7 @@
+7.0.1
+	+ Security fix: LDAP authentication is not secure on its own. 
+	  A passive eavesdropper could learn your LDAP password by 
+	  listening in on traffic in flight, so we use Kerberos auth instead.
 7.0.0
 	+ Set version number to 7.0.0
 6.2.0

--- a/main/radius/debian/changelog
+++ b/main/radius/debian/changelog
@@ -1,3 +1,9 @@
+zentyal-radius (7.0.1) focal; urgency=medium
+
+  * New upstream release
+
+ -- Christian Tosta <devel@cpuhouse.com.br>  Thu, 19 Aug 2021 11:53:16 -0300
+
 zentyal-radius (7.0.0) focal; urgency=low
 
   * New upstream release

--- a/main/radius/stubs/default.mas
+++ b/main/radius/stubs/default.mas
@@ -412,7 +412,7 @@ authorize {
 
 	#
 	#  The ldap module reads passwords from the LDAP database.
-#	-ldap
+	ldap
 
 	#
 	#  Enforce daily limits on time spent logged in.
@@ -435,13 +435,21 @@ authorize {
 	#
 	pap
 
-    # If no Auth-Type was sent, we assume PAP but that we should
-    # use ntlm_auth for AD authentication through ntlm_auth.
-    if (!control:Auth-Type) {
-        update control {
-            Auth-Type = "LDAP"
-        }
-    }
+	# If no Auth-Type was sent and User-Password was sent we should
+	# use Kerberos for AD authentication through krb5.
+	if ((!control:Auth-Type) && User-Password) {
+		update control {
+			Auth-Type := Kerberos
+		}
+	}
+
+	# If no Auth-Type was sent, we assume PAP but that we should
+	# use ntlm_auth for AD authentication through ntlm_auth.
+#	if (!control:Auth-Type) {
+#		update control {
+#			Auth-Type = "LDAP"
+#		}
+#	}
 
 	#
 	#  If "status_server = yes", then Status-Server messages are passed
@@ -517,6 +525,12 @@ authenticate {
 #	digest
 
 	#
+	# Kerberos authentication against AD.
+	Auth-Type Kerberos {
+		krb5
+	}
+
+	#
 	#  Pluggable Authentication Modules.
 #	pam
 
@@ -531,9 +545,9 @@ authenticate {
 	#  authentication server, and knows what to do with authentication.
 	#  LDAP servers do not.
 	#
-	Auth-Type LDAP {
-		ldap
-	}
+#	Auth-Type LDAP {
+#		ldap
+#	}
 
 	#
 	#  Allow EAP authentication.

--- a/main/radius/stubs/krb5.mas
+++ b/main/radius/stubs/krb5.mas
@@ -1,0 +1,86 @@
+<%args>
+    $keytab
+    $service_principal
+</%args>
+# -*- text -*-
+#
+#  $Id: c88b5fbb4b35cc4e61bfb93a616d891fb79ebc0c $
+
+#
+#  Kerberos.  See doc/modules/rlm_krb5 for minimal docs.
+#
+krb5 {
+	#
+	#  The keytab file MUST be owned by the UID/GID used by the server.
+	#  The keytab file MUST be writable by the server.
+	#  The keytab file MUST NOT be readable by other users on the system.
+	#  The keytab file MUST exist before the server is started.
+	#
+	keytab = <% $keytab %>
+	service_principal = <% $service_principal %>
+
+	#  Pool of krb5 contexts, this allows us to make the module multithreaded
+	#  and to avoid expensive operations like resolving and opening keytabs
+	#  on every request.  It may also allow TCP connections to the KDC to be
+	#  cached if that is supported by the version of libkrb5 used.
+	#
+	#  The context pool is only used if the underlying libkrb5 reported
+	#  that it was thread safe at compile time.
+	#
+	pool {
+		#  Connections to create during module instantiation.
+		#  If the server cannot create specified number of
+		#  connections during instantiation it will exit.
+		#  Set to 0 to allow the server to start without the
+		#  KDC being available.
+		start = ${thread[pool].start_servers}
+
+		#  Minimum number of connections to keep open
+		min = ${thread[pool].min_spare_servers}
+
+		#  Maximum number of connections
+		#
+		#  If these connections are all in use and a new one
+		#  is requested, the request will NOT get a connection.
+		#
+		#  Setting 'max' to LESS than the number of threads means
+		#  that some threads may starve, and you will see errors
+		#  like 'No connections available and at max connection limit'
+		#
+		#  Setting 'max' to MORE than the number of threads means
+		#  that there are more connections than necessary.
+		max = ${thread[pool].max_servers}
+
+		#  Spare connections to be left idle
+		#
+		#  NOTE: Idle connections WILL be closed if "idle_timeout"
+		#  is set.  This should be less than or equal to "max" above.
+		spare = ${thread[pool].max_spare_servers}
+
+		#  Number of uses before the connection is closed
+		#
+		#  0 means "infinite"
+		uses = 0
+
+		#  The lifetime (in seconds) of the connection
+		#
+		#  NOTE: A setting of 0 means infinite (no limit).
+		lifetime = 0
+
+		#  The idle timeout (in seconds).  A connection which is
+		#  unused for this length of time will be closed.
+		#
+		#  NOTE: A setting of 0 means infinite (no timeout).
+		idle_timeout = 0
+
+		#  NOTE: All configuration settings are enforced.  If a
+		#  connection is closed because of "idle_timeout",
+		#  "uses", or "lifetime", then the total number of
+		#  connections MAY fall below "min".  When that
+		#  happens, it will open a new connection.  It will
+		#  also log a WARNING message.
+		#
+		#  The solution is to either lower the "min" connections,
+		#  or increase lifetime/idle_timeout.
+	}
+}

--- a/main/radius/stubs/ldap.mas
+++ b/main/radius/stubs/ldap.mas
@@ -120,6 +120,9 @@ ldap {
 #		reply:Tunnel-Type		:= 'radiusTunnelType'
 #		reply:Tunnel-Medium-Type	:= 'radiusTunnelMediumType'
 #		reply:Tunnel-Private-Group-ID	:= 'radiusTunnelPrivategroupId'
+                reply:Framed-IP-Address         := 'radiusFramedIPAddress'
+                reply:Framed-IP-Netmask         := 'radiusFramedIPNetmask'
+                reply:Framed-Route              += 'radiusFramedRoute'
 
 		#  Where only a list is specified as the RADIUS attribute,
 		#  the value of the LDAP attribute is parsed as a valuepair


### PR DESCRIPTION
A passive eavesdropper could learn your LDAP password by listening
in on traffic in flight, so use Kerberos auth instead.