### PR TITLE
Fix integration with the log module

### DIFF
--- a/main/openvpn/ChangeLog
+++ b/main/openvpn/ChangeLog
@@ -1,3 +1,5 @@
+8.0.1
+	+ Fix integration with the log module
 8.0.0
 	+ Set version to 8.0.0
 	+ Changed deprecated Quagga for Frr package

--- a/main/openvpn/debian/changelog
+++ b/main/openvpn/debian/changelog
@@ -1,3 +1,9 @@
+zentyal-openvpn (8.0.1) jammy; urgency=high
+
+  * New upstream release
+
+ -- Daniel Joven <djoven@novadevs.com>  Wed, 01 Oct 2025 10:44:27 +0100
+
 zentyal-openvpn (8.0.0) jammy; urgency=medium
 
   * New upstream release

--- a/main/openvpn/src/EBox/OpenVPN/LogHelper.pm
+++ b/main/openvpn/src/EBox/OpenVPN/LogHelper.pm
@@ -103,7 +103,7 @@ sub processLine # (file, line, logger)
 {
     my ($self, $file, $line, $dbengine) = @_;
 
-    my ($wday, $month, $mday, $time, $year, $msg) = split '\s+', $line, 6;
+    my ($year, $time, $msg) = split /\s+/, $line, 3;
 
     my $eventInfo = $self->_eventFromMsg($msg);
     if (not defined $eventInfo) {
@@ -119,7 +119,7 @@ sub processLine # (file, line, logger)
     my $name   = $daemon->{name};
     my $type   = $daemon->{type};
 
-    my $timestamp = $self->_convertTimestamp("$month $mday $time $year", '%b %e %H:%M:%S %Y');
+    my $timestamp = $year . ' ' . $time;
 
     my $dbRow = {
                  timestamp  => $timestamp,


### PR DESCRIPTION
The OpenVPN module cannot record events in the log module due to a change in its log format.