### PR TITLE
Fix the Fetchmail service because of the CVE-2025-61962

### DIFF
--- a/main/mail/ChangeLog
+++ b/main/mail/ChangeLog
@@ -1,3 +1,5 @@
+8.0.1
+	+ Fix the Fetchmail service because of the CVE-2025-61962
 8.0.0
 	+ Set version to 8.0.0
 	+ Update initial-setup and enable-module scripts

--- a/main/mail/debian/changelog
+++ b/main/mail/debian/changelog
@@ -1,3 +1,9 @@
+zentyal-mail (8.0.1) jammy; urgency=high
+
+  * New upstream release
+
+ -- Daniel Joven <djoven@novadevs.com>  Fri, 31 Oct 2025 12:47:28 +0100
+
 zentyal-mail (8.0.0) jammy; urgency=medium
 
   * New upstream release

--- a/main/mail/debian/zentyal.fetchmail.service
+++ b/main/mail/debian/zentyal.fetchmail.service
@@ -2,5 +2,9 @@
 Description=Zentyal fetchmail daemon
 
 [Service]
-ExecStart=/bin/su fetchmail -c '/usr/bin/fetchmail --nodetach -f /etc/zentyal-fetchmail.rc'
-Restart=on-failure
+Type=simple
+User=fetchmail
+ExecStart=/usr/bin/fetchmail --nodetach -f /etc/zentyal-fetchmail.rc
+Restart=always
+SuccessExitStatus=1
+RestartSec=30


### PR DESCRIPTION
The latest update of Fetchmail causes the zentyal.fetchmail service crashes.

The relevant links about the Fetchmail update that causes the bug:
* https://ubuntu.com/security/notices/USN-7838-1
* https://www.fetchmail.info/fetchmail-SA-2025-01.txt