### PR TITLE
Improve CA certificate listing performance

### DIFF
--- a/main/ca/ChangeLog
+++ b/main/ca/ChangeLog
@@ -1,3 +1,7 @@
+HEAD
+	+ Improve certificate listing performance by skipping eager subject alternative names extraction when not needed
+	+ Cache CA distinguished name through caDN() to avoid repeated openssl calls
+	+ Skip recursive chown after read-only x509 metadata commands
 8.1.0
 	+ Set version to 8.1.0
 8.0.1

--- a/main/ca/src/EBox/CA.pm
+++ b/main/ca/src/EBox/CA.pm
@@ -470,7 +470,8 @@ sub revokeCACertificate
     # Revoked only valid ones
     # We ensure not to revoke the CA cert before the others
     my $listCerts = $self->listCertificates( state => 'V',
-            excludeCA => 1);
+            excludeCA => 1,
+            includeSubjAltNames => 0);
     foreach my $element (@{$listCerts}) {
         $self->revokeCertificate(commonName    => $element->{dn}->attribute('commonName'),
                 reason        => "cessationOfOperation",
@@ -606,7 +607,7 @@ sub renewCACertificate
 
     $self->{caKeyPassword} = $args{caKeyPassword};
 
-    my $listCerts = $self->listCertificates();
+    my $listCerts = $self->listCertificates(includeSubjAltNames => 0);
 
     my $renewedCert = $self->renewCertificate( countryName   => $args{countryName},
             stateName     => $args{stateName},
@@ -1034,6 +1035,9 @@ sub generateCRL
 #       excludeCA - boolean indicating whether the valid CA certificate
 #                   should be excluded in the response (Optional)
 #
+#       includeSubjAltNames - boolean indicating whether the subject alternative
+#                             names should be included in the response (Optional)
+#
 #       - Named parameters
 #
 # Returns:
@@ -1067,6 +1071,8 @@ sub listCertificates
     # Getting the arguments
     my $state = $args{'state'};
     my $excludeCA = $args{'excludeCA'};
+    my $includeSubjAltNames = $args{'includeSubjAltNames'};
+    $includeSubjAltNames = 1 unless defined($includeSubjAltNames);
     # Check parameter state is correct (R, V or E)
     if (defined($state) and $state !~ m/[RVE]/ ) {
         throw EBox::Exceptions::Internal("State should be R, V or E");
@@ -1110,7 +1116,9 @@ sub listCertificates
         }
 
         # Setting the subject alternative names
-        $element{'subjAltNames'} = $self->_obtain( $element{'path'}, 'subjAltNames' );
+        if ($includeSubjAltNames) {
+            $element{'subjAltNames'} = $self->_obtain( $element{'path'}, 'subjAltNames' );
+        }
 
         push (@out, \%element);
 
@@ -1184,7 +1192,7 @@ sub getCertificateMetadata
     my $dn = $args{'dn'};
     my $serialNumber = $args{'serialNumber'};
 
-    my $listCertsRef = $self->listCertificates();
+    my $listCertsRef = $self->listCertificates(includeSubjAltNames => 0);
 
     my $retCert = undef;
     if (defined($cn)) {
@@ -1195,6 +1203,10 @@ sub getCertificateMetadata
         ($retCert) = grep { $_->{'dn'}->equals($dn) } @{$listCertsRef};
     } elsif( defined($serialNumber) ) {
         ($retCert) = grep { $_->{'serialNumber'} eq $serialNumber } @{$listCertsRef};
+    }
+
+    if (defined($retCert)) {
+        $retCert->{subjAltNames} = $self->_obtain($retCert->{path}, 'subjAltNames');
     }
 
     return $retCert;
@@ -1221,7 +1233,7 @@ sub getCACertificateMetadata
 {
     my ($self) = @_;
 
-    my $certsRef = $self->listCertificates();
+    my $certsRef = $self->listCertificates(includeSubjAltNames => 0);
 
     # Find the CA certificate in the list
     my ($CACert) = grep { $_->{'isCACert'} } @{$certsRef} ;
@@ -1618,7 +1630,7 @@ sub updateDB
         $self->{caKeyPassword} = $caKeyPassword;
     }
 
-    my @expiredCertsBefore = @{$self->listCertificates(state => 'E')};
+    my @expiredCertsBefore = @{$self->listCertificates(state => 'E', includeSubjAltNames => 0)};
 
     my $cmd = "ca";
     $self->_commonArgs("ca", \$cmd);
@@ -1631,7 +1643,7 @@ sub updateDB
     my ($retVal, $output) = $self->_executeCommand( command => $cmd );
     delete( $ENV{'PASS'} );
 
-    my @expiredCertsAfter = @{$self->listCertificates(state => 'E')};
+    my @expiredCertsAfter = @{$self->listCertificates(state => 'E', includeSubjAltNames => 0)};
     my %seen;
     my @diff;
     foreach my $item (@expiredCertsBefore) {
@@ -2423,7 +2435,7 @@ sub _isCACert # (EBox::CA::DN dn)
 {
     my ($self, $dn) = @_;
 
-    my $caDN = $self->_obtain(CACERT, 'DN');
+    my $caDN = $self->caDN();
 
     return $caDN->equals($dn);
 }
@@ -2627,7 +2639,9 @@ sub _executeCommand # (command, input, hide_output)
 
     my $return = EBox::Sudo::root("openssl $command");
     ## TODO: Find a better way to set the permissions
-    EBox::Sudo::silentRoot("chown -R ebox:ebox " . CATOPDIR);
+    unless ($command =~ m/^x509\s/ and $command =~ m/\s-noout\s/) {
+        EBox::Sudo::silentRoot("chown -R ebox:ebox " . CATOPDIR);
+    }
 
    my $input;
    $input = $params{input} if (exists $params{input});

--- a/main/ca/src/EBox/CA/CGI/Index.pm
+++ b/main/ca/src/EBox/CA/CGI/Index.pm
@@ -68,7 +68,7 @@ sub masonParameters
             return [error => "$ex"];
         }
 
-        push( @array, 'certs' => $ca->listCertificates() );
+        push( @array, 'certs' => $ca->listCertificates(includeSubjAltNames => 0) );
 
         # Check if a new CA certificate is needed (because of revokation from RevokeCertificate)
         my $currentState;

--- a/main/ca/src/templates/index.mas
+++ b/main/ca/src/templates/index.mas
@@ -117,12 +117,7 @@ use EBox::CA::DN;
 %      $caCertName = $cert->{'dn'}->attribute('commonName');
        <tr class="highlight">
 %     }
-     <td class="tleft"
-%     if ( defined($cert->{'subjAltNames'}) and @{$cert->{'subjAltNames'}} > 0 ) {
-%            my $subjAltNamesStr = join(', ', map { qq{$_->{type}: $_->{value}} } @{$cert->{'subjAltNames'}});
-             title="<% $subjAltNamesStr %>"
-% }
-         >
+     <td class="tleft">
 %     if ( $cert->{'isCACert'} ) {
         <% $cert->{'dn'}->attribute('commonName') %>
         <% __('from') %>

--- a/main/openvpn/ChangeLog
+++ b/main/openvpn/ChangeLog
@@ -1,3 +1,5 @@
+HEAD
+	+ Skip subject alternative names extraction when listing certificates in CAIsReady, availableCertificates and VPN server configuration
 8.1.0
 	+ Set version to 8.1.0
 8.0.2

--- a/main/openvpn/src/EBox/OpenVPN.pm
+++ b/main/openvpn/src/EBox/OpenVPN.pm
@@ -758,7 +758,9 @@ sub CAIsReady
     }
 
     my $nValidCertificates =
-      grep {$_->{state} eq 'V'} @{  $ca->listCertificates  };
+      grep {$_->{state} eq 'V'} @{
+          $ca->listCertificates(includeSubjAltNames => 0)
+      };
 
     my $ready =
       ($nValidCertificates >= 2); # why 2? bz we need the CA certificate and

--- a/main/openvpn/src/EBox/OpenVPN.pm
+++ b/main/openvpn/src/EBox/OpenVPN.pm
@@ -906,7 +906,8 @@ sub availableCertificates
 
     my $ca = EBox::Global->modInstance('ca');
     return [] unless ($ca->isCreated());
-    my $certificates_r = $ca->listCertificates(state => 'V', excludeCA => 1);
+    my $certificates_r = $ca->listCertificates(state => 'V', excludeCA => 1,
+            includeSubjAltNames => 0);
     my @certificatesCN =
       map {$_->{dn}->attribute('commonName');} @{$certificates_r};
 

--- a/main/openvpn/src/EBox/OpenVPN/Model/Servers.pm
+++ b/main/openvpn/src/EBox/OpenVPN/Model/Servers.pm
@@ -410,7 +410,7 @@ sub _configureVPN
     my $ca = EBox::Global->modInstance('ca');
     my $name = $row->valueByName('name');
     my $certName = "vpn-$name";
-    my @certs = @{$ca->listCertificates()};
+    my @certs = @{$ca->listCertificates(includeSubjAltNames => 0)};
     unless (List::Util::first { $_->{dn}->{commonName} eq $certName } @certs ) {
         my $caExpiration = $ca->getCACertificateMetadata()->{expiryDate};
         $ca->issueCertificate(commonName => $certName , endDate => $caExpiration);


### PR DESCRIPTION
## Summary
- Add an optional `includeSubjAltNames` flag to `listCertificates()`, keeping the default SAN-inclusive behavior for compatibility.
- Skip SAN extraction in CA/OpenVPN paths that only need certificate state, DN, serial, expiry, or common name.
- Cache CA DN comparison through `caDN()` and avoid recursive `chown -R` after read-only `openssl x509 ... -noout` metadata calls.

## Testing
- `git diff --check`
- Live affected Zentyal 8.1 system: `perl -c /usr/share/perl5/EBox/CA.pm`
- Live affected Zentyal 8.1 system: `perl -c /usr/share/perl5/EBox/CA/CGI/Index.pm`
- Live benchmark with 192 CA index entries:
  - `listCertificates(includeSubjAltNames => 1)`: 14.670s
  - `listCertificates(includeSubjAltNames => 0)`: 0.016s
  - `updateDB()`: 0.610s

Fixes #2224
Related to #2168 and #2201